### PR TITLE
upstream-images target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,37 @@
+BUILD=build
+KUBE_ADDONS=addon-resizer coredns defaultbackend heapster k8s-dns kubernetes-dashboard metrics-server
+KUBE_ADDONS_REGISTRY=k8s.gcr.io
 KUBE_ARCH=amd64
+KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+KUBE_ERSION=$(subst v,,${KUBE_VERSION})
+PWD=$(shell pwd)
+
+## Pin some addons to known-good versions
 # Need upstream issue resolved before we can bump ceph-csi commit
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=3ec05335204d92842edb288f10c715bc84333960
 KUBE_DASHBOARD_VERSION=v1.10.1
-KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
-KUBE_ERSION=$(subst v,,${KUBE_VERSION})
-PWD=$(shell pwd)
-BUILD=build
 
-default: clean
+prep: clean
 	cp -r cdk-addons ${BUILD}
 	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} COREDNS_COMMIT=${COREDNS_COMMIT} ./get-addon-templates
 	mv templates ${BUILD}
+
+
+default: prep
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl
 	chmod +x ${BUILD}/kubectl
 	sed 's/KUBE_VERSION/${KUBE_ERSION}/g' cdk-addons.yaml > ${BUILD}/snapcraft.yaml
 	sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" ${BUILD}/snapcraft.yaml
 	cd ${BUILD} && snapcraft
 	mv build/*.snap .
+
+
+upstream-images: prep
+	$(eval RAW_IMAGES := "$(foreach raw,${KUBE_ADDONS},$(shell grep -hoE 'image:.*${raw}.*' ./${BUILD}/templates/*.yaml | sort -u))")
+	@echo ${RAW_IMAGES} | sed -e 's|image: ||g' -e 's|{{ arch }}|${KUBE_ARCH}|g' -e 's|{{[^}]*}}|${KUBE_ADDONS_REGISTRY}|g'
+
 
 docker: clean
 	docker build -t cdk-addons-builder .

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=3ec05335204d92842edb288f10c715bc84333960
 KUBE_DASHBOARD_VERSION=v1.10.1
 
+.PHONY: prep
 prep: clean
 	cp -r cdk-addons ${BUILD}
 	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} COREDNS_COMMIT=${COREDNS_COMMIT} ./get-addon-templates
@@ -30,7 +31,8 @@ default: prep
 
 upstream-images: prep
 	$(eval RAW_IMAGES := "$(foreach raw,${KUBE_ADDONS},$(shell grep -hoE 'image:.*${raw}.*' ./${BUILD}/templates/*.yaml | sort -u))")
-	@echo ${RAW_IMAGES} | sed -e 's|image: ||g' -e 's|{{ arch }}|${KUBE_ARCH}|g' -e 's|{{[^}]*}}|${KUBE_ADDONS_REGISTRY}|g'
+	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -e 's|image: ||g' -e 's|{{ arch }}|${KUBE_ARCH}|g' -e 's|{{[^}]*}}|${KUBE_ADDONS_REGISTRY}|g'))
+	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
 
 
 docker: clean

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -107,12 +107,12 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     content = content.replace("amd64", "{{ arch }}")
     content = content.replace("clusterIP: {{ pillar['dns_server'] }}", "# clusterIP: {{ pillar['dns_server'] }}")
     content = content.replace(
-		"gcr.io/google_containers/addon-resizer:1.8.1",
-		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
+        "gcr.io/google_containers/addon-resizer:1.8.1",
+        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
     content = content.replace(
-		"k8s.gcr.io/addon-resizer:1.8.1",
-		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
+        "k8s.gcr.io/addon-resizer:1.8.1",
+        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",


### PR DESCRIPTION
- Add a make target that will output the image location of the addons that we support with cdk-addons.
- Fix a couple whitespace issues while I'm here.

Here's the business end:
```bash
$ make upstream-images
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0     40      0  0:00:04  0:00:04 --:--:--    40
100     8    0     8    0     0      0      0 --:--:--  0:00:09 --:--:--     2
cp -r cdk-addons build
KUBE_VERSION=v1.14.1 KUBE_DASHBOARD_VERSION=v1.10.1 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6 COREDNS_COMMIT=3ec05335204d92842edb288f10c715bc84333960 ./get-addon-templates
INFO:__main__:Cloning https://github.com/kubernetes/kubernetes.git branch v1.14.1
INFO:__main__:Copying addons to /Users/kwmonroe/charms/src/cdk-addons/templates
INFO:__main__:Cloning https://github.com/kubernetes/dashboard.git branch v1.10.1
INFO:__main__:Copying dashboard to /Users/kwmonroe/charms/src/cdk-addons/templates
INFO:__main__:Cloning https://github.com/NVIDIA/k8s-device-plugin.git
INFO:__main__:Copying nvidia plugin to /Users/kwmonroe/charms/src/cdk-addons/templates
INFO:__main__:Cloning http://github.com/ceph/ceph-csi.git commit a4dd8457350b4c4586743d78cbd5776437e618b6
INFO:__main__:Copying ceph CSI templates to /Users/kwmonroe/charms/src/cdk-addons/templates
INFO:__main__:Cloning https://github.com/kubernetes/cloud-provider-openstack.git
INFO:__main__:Copying openstack tempates to /Users/kwmonroe/charms/src/cdk-addons/templates
INFO:__main__:Cloning https://github.com/coredns/deployment.git commit 3ec05335204d92842edb288f10c715bc84333960
INFO:__main__:Copying coredns template to /Users/kwmonroe/charms/src/cdk-addons/templates
mv templates build
k8s.gcr.io/addon-resizer:1.8.4 coredns/coredns:1.4.0  k8s.gcr.io/heapster-grafana-amd64:v4.4.3 k8s.gcr.io/heapster-influxdb-amd64:v1.3.3 k8s.gcr.io/heapster-amd64:v1.6.0-beta.1 k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13 k8s.gcr.io/k8s-dns-kube-dns:1.14.13 k8s.gcr.io/k8s-dns-sidecar:1.14.13 k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1 k8s.gcr.io/metrics-server-amd64:v0.3.1
```

To be clear, that last line is the important one:
```bash
k8s.gcr.io/addon-resizer:1.8.4 coredns/coredns:1.4.0  k8s.gcr.io/heapster-grafana-amd64:v4.4.3 k8s.gcr.io/heapster-influxdb-amd64:v1.3.3 k8s.gcr.io/heapster-amd64:v1.6.0-beta.1 k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13 k8s.gcr.io/k8s-dns-kube-dns:1.14.13 k8s.gcr.io/k8s-dns-sidecar:1.14.13 k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1 k8s.gcr.io/metrics-server-amd64:v0.3.1
```

We'll use this in a CI job to write to an official "images per release" file, which will be the source of truth for upstream images used in CDK (at least the ones that are easily discoverable).