### PR TITLE
 backport upstream-images target #95 to 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,38 @@
+BUILD=build
+KUBE_ADDONS=addon-resizer defaultbackend heapster k8s-dns kubernetes-dashboard metrics-server
+KUBE_ADDONS_REGISTRY=k8s.gcr.io
 KUBE_ARCH=amd64
+KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+KUBE_ERSION=$(subst v,,${KUBE_VERSION})
+PWD=$(shell pwd)
+
+## Pin some addons to known-good versions
 # ceph-csi can't go past this commit for k8s 1.12 because csi v1.0.0 is not
 # supported
 CEPH_CSI_COMMIT=088cfc553802f99fd22b919ff4e24910420dc8ce
 KUBE_DASHBOARD_VERSION=v1.10.1
-KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
-KUBE_ERSION=$(subst v,,${KUBE_VERSION})
-PWD=$(shell pwd)
-BUILD=build
 
-default: clean
+.PHONY: prep
+prep: clean
 	cp -r cdk-addons ${BUILD}
 	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} ./get-addon-templates
 	mv templates ${BUILD}
+
+
+default: prep
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl
 	chmod +x ${BUILD}/kubectl
 	sed 's/KUBE_VERSION/${KUBE_ERSION}/g' cdk-addons.yaml > ${BUILD}/snapcraft.yaml
 	sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" ${BUILD}/snapcraft.yaml
 	cd ${BUILD} && snapcraft
 	mv build/*.snap .
+
+
+upstream-images: prep
+	$(eval RAW_IMAGES := "$(foreach raw,${KUBE_ADDONS},$(shell grep -hoE 'image:.*${raw}.*' ./${BUILD}/templates/*.yaml | sort -u))")
+	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -e 's|image: ||g' -e 's|{{ arch }}|${KUBE_ARCH}|g' -e 's|{{[^}]*}}|${KUBE_ADDONS_REGISTRY}|g'))
+	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
+
 
 docker: clean
 	docker build -t cdk-addons-builder .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILD=build
 KUBE_ADDONS=addon-resizer defaultbackend heapster k8s-dns kubernetes-dashboard metrics-server
 KUBE_ADDONS_REGISTRY=k8s.gcr.io
 KUBE_ARCH=amd64
-KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable-1.12.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -102,12 +102,12 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     content = content.replace("amd64", "{{ arch }}")
     content = content.replace("clusterIP: {{ pillar['dns_server'] }}", "# clusterIP: {{ pillar['dns_server'] }}")
     content = content.replace(
-		"gcr.io/google_containers/addon-resizer:1.8.1",
-		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
+        "gcr.io/google_containers/addon-resizer:1.8.1",
+        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
     content = content.replace(
-		"k8s.gcr.io/addon-resizer:1.8.1",
-		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
+        "k8s.gcr.io/addon-resizer:1.8.1",
+        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",


### PR DESCRIPTION
- lock KUBE_VERSION to 1.12
- backport #95 