### PR TITLE
backport external openstack provider support #91 to 1.13

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=180
+ignore=E302,E305,W504

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PWD=$(shell pwd)
 # Need upstream issue resolved before we can bump ceph-csi commit
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
+# pin cloud-provider-openstack because it's under active dev
+OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9
 KUBE_DASHBOARD_VERSION=v1.10.1
 
 default: prep
@@ -29,7 +31,7 @@ docker: clean
 
 prep: clean
 	cp -r cdk-addons ${BUILD}
-	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} ./get-addon-templates
+	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} OPENSTACK_PROVIDER_COMMIT=${OPENSTACK_PROVIDER_COMMIT} ./get-addon-templates
 	mv templates ${BUILD}
 
 upstream-images: prep

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -141,6 +141,23 @@ def render_templates():
         render_template("keystone-service.yaml", keystone_context)
         render_template("keystone-rbac.yaml", keystone_context)
         rendered = True
+    if get_snap_config("enable-openstack", required=False) == "true":
+        openstack_context = context.copy()
+        openstack_context.update({
+            "cloud_conf": get_snap_config("openstack-cloud-conf", required=True),
+            "endpoint_ca_cert": get_snap_config("openstack-endpoint-ca", required=False),
+        })
+
+        render_template("openstack-cloud-controller-manager-ds.yaml", openstack_context)
+        render_template("cloud-config-secret.yaml", openstack_context)
+
+        render_template("cinder-csi-controllerplugin-rbac.yaml", openstack_context)
+        render_template("cinder-csi-controllerplugin.yaml", openstack_context)
+        render_template("cinder-csi-nodeplugin-rbac.yaml", openstack_context)
+        render_template("cinder-csi-nodeplugin.yaml", openstack_context)
+        render_template("cinder-csi-storageclass.yaml", openstack_context)
+        rendered = True
+
     return rendered
 
 def render_template(file, context, required=True, render_filename=None):

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -5,10 +5,11 @@ rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
 for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns \
-		enable-metrics enable-gpu registry \
-		ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
-		default-storage enable-ceph enable-keystone keystone-server-url \
-		keystone-cert-file keystone-key-file keystone-server-ca \
-		dashboard-auth; do
-	snapctl get "$key" > "$SNAP_DATA/config/$key"
+           enable-metrics enable-gpu registry \
+           ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
+           default-storage enable-ceph enable-keystone keystone-server-url \
+           keystone-cert-file keystone-key-file keystone-server-ca \
+           dashboard-auth enable-openstack openstack-cloud-conf \
+           openstack-endpoint-ca; do
+    snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -11,6 +11,7 @@ import logging
 import yaml
 from contextlib import contextmanager
 from functools import partial
+from pathlib import Path
 
 
 description = """
@@ -82,7 +83,8 @@ ceph_csi_repo = repo_cloner(
 )
 
 cloud_provider_openstack_repo = repo_cloner(
-    url="https://github.com/kubernetes/cloud-provider-openstack.git"
+    url="https://github.com/kubernetes/cloud-provider-openstack.git",
+    commit=os.environ["OPENSTACK_PROVIDER_COMMIT"]
 )
 
 
@@ -229,6 +231,45 @@ def patch_keystone_deployment(repo, file):
         f.write(content)
 
 
+def patch_openstack_secret(repo, file):
+    """
+    Replace the hard-coded cloud.conf value with a template param.
+    """
+    source = Path(repo) / file
+    content = source.read_text()
+    content = re.sub(r'cloud.conf: .*', 'cloud.conf: {{ cloud_conf }}', content)
+    content += '{% if endpoint_ca_cert %}  endpoint-ca.cert: {{ endpoint_ca_cert }}\n{% endif %}'
+    source.write_text(content)
+
+
+def patch_openstack_ccm(repo, file):
+    source = Path(repo) / file
+    content = source.read_text()
+    content = content.replace('      nodeSelector:\n'
+                              '        node-role.kubernetes.io/master: ""\n', '')
+    source.write_text(content)
+
+
+def patch_openstack_registries(repo, file):
+    source = Path(repo) / file
+    content = source.read_text()
+    content = content.replace('image: docker.io/k8scloudprovider/',
+                              'image: {{ registry|default("docker.io/k8scloudprovider") }}/')
+    content = content.replace('image: quay.io/k8scsi/',
+                              'image: {{ registry|default("quay.io/k8scsi") }}/')
+    source.write_text(content)
+
+
+def patch_cinder_sc(repo, file):
+    source = Path(repo) / file
+    content = yaml.load_all(source.read_text())
+    content = list(content)[0]  # we only want the first part; the storage class
+    if content['kind'] != 'StorageClass':
+        raise ValueError('Unexpected change to OpenStack Cinder CSI storage class example')
+    content['metadata']['name'] = 'cinder'
+    source.write_text(yaml.safe_dump(content))
+
+
 def patch_dashboard(repo, file):
     source = os.path.join(repo, file)
     with open(source, "r") as f:
@@ -308,6 +349,23 @@ def get_addon_templates():
         add_addon(repo, "examples/webhook/keystone-deployment.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-service.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-rbac.yaml", dest, base='.')
+
+        patch_openstack_secret(repo, "manifests/controller-manager/cloud-config-secret.yaml")
+        patch_openstack_ccm(repo, "manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml")
+        patch_openstack_registries(repo, "manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml")
+
+        add_addon(repo, "manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml", dest, base='.')
+        add_addon(repo, "manifests/controller-manager/cloud-config-secret.yaml", dest, base='.')
+
+        patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml")
+        patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml")
+        patch_cinder_sc(repo, "examples/cinder-csi-plugin/nginx.yaml")
+
+        add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml", dest, base='.')
+        add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml", dest, base='.')
+        add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml", dest, base='.')
+        add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml", dest, base='.')
+        add_addon(repo, "examples/cinder-csi-plugin/nginx.yaml", os.path.join(dest, "cinder-csi-storageclass.yaml"), base='.')
 
 
 def parse_args():


### PR DESCRIPTION
This adds the openstack-cloud-controller-manager and csi-cinder-plugin components to enable using the external cloud provider when OpenStack integration is used.