### PR TITLE
add quay.io to the repos we sub with 'registry' config

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -126,6 +126,9 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     content = re.sub(r"image:\s*nvidia/",
                      "image: {{ registry|default('nvidia') }}/",
                      content)
+    content = re.sub(r"image:\s*quay.io/",
+                     "image: {{ registry|default('quay.io') }}/",
+                     content)
     with open(dest, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
We substitute a few repos with whatever we have snap configured as 'registry'.  This includes nvidia and k8s.gcr.io, but was missing quay.  Add that since it's a common repo from which to find images, eg:

https://github.com/ceph/ceph-csi/blob/master/deploy/rbd/kubernetes/csi-rbdplugin.yaml