### PR TITLE
adjust default registry for openstack images

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -228,7 +228,7 @@ def patch_keystone_deployment(repo, file):
     with open(source, "r") as f:
         content = f.read()
     content = content.replace('image: k8scloudprovider/k8s-keystone-auth',
-                              'image: {{ registry|default("k8scloudprovider") }}/k8s-keystone-auth') # noqa
+                              'image: {{ registry|default("docker.io") }}/k8scloudprovider/k8s-keystone-auth')
     content = content.replace("            - --keystone-url",
                               """{% if keystone_server_ca %}
             - --keystone-ca-file
@@ -262,9 +262,9 @@ def patch_openstack_registries(repo, file):
     source = Path(repo) / file
     content = source.read_text()
     content = content.replace('image: docker.io/k8scloudprovider/',
-                              'image: {{ registry|default("docker.io/k8scloudprovider") }}/')
+                              'image: {{ registry|default("docker.io") }}/k8scloudprovider/')
     content = content.replace('image: quay.io/k8scsi/',
-                              'image: {{ registry|default("quay.io/k8scsi") }}/')
+                              'image: {{ registry|default("quay.io") }}/k8scsi/')
     source.write_text(content)
 
 


### PR DESCRIPTION
k8scsi and k8s-keystone images have a prefix in the registry path; preserve that when we either substitute a configured registry or use a default value.