### PR TITLE
generic snapcraft vs cleanbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ default: prep
 	chmod +x ${BUILD}/kubectl
 	sed 's/KUBE_VERSION/${KUBE_ERSION}/g' cdk-addons.yaml > ${BUILD}/snapcraft.yaml
 	sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" ${BUILD}/snapcraft.yaml
-	cd ${BUILD} && snapcraft build
+# NB: do not call cleanbuild as jenkins cannot run the confined lxd snap from /var/lib/jenkins.
+# Generic build is safe here as the snap doesnt build anything, hence cant be polluted from the host.
+	cd ${BUILD} && snapcraft
 	mv build/*.snap .
 
 clean:


### PR DESCRIPTION
snapd 2.37.2 and above cannot run the confined lxd snap from
jenkins home (/var/lib/jenkins):

https://github.com/snapcore/snapd/commit/267adf0492f798066d21b8e1ffa1d17ee2d1b368

Since this snap is just a dump plus a shell script, it is safe to
run snapcraft without cleanbuild and still be confident this snap will
not be polluted from the build host.