### PR TITLE
preserve cdkbot and nvidia image prefixes

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -118,13 +118,13 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",
-                     "image: {{ registry|default('cdkbot') }}/",
+                     "image: {{ registry|default('docker.io') }}/cdkbot/",
                      content)
     content = re.sub(r"image:\s*k8s.gcr.io/",
                      "image: {{ registry|default('k8s.gcr.io') }}/",
                      content)
     content = re.sub(r"image:\s*nvidia/",
-                     "image: {{ registry|default('nvidia') }}/",
+                     "image: {{ registry|default('docker.io') }}/nvidia/",
                      content)
     content = re.sub(r"image:\s*quay.io/",
                      "image: {{ registry|default('quay.io') }}/",


### PR DESCRIPTION
We've adopted a convention of preserving image path prefixes when pushing images to Canonical's registry. That is, if you need `cdkbot/pause` in a private registry, you're expected to put it in `$registry/cdkbot/pause`. We've done that pretty well for stuff from k8s.gcr.io and quay.io, but haven't been good with the docker hub images.

Make sure we do that for `docker.io` images that come from `/cdkbot` and `/nvidia`.