### PR TITLE
lp:1822761 bump influxdb container mem to 800M

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -188,6 +188,16 @@ def patch_heapster_controller(repo, file):
         f.write(content)
 
 
+def patch_influxdb_grafana(repo, file):
+    source = os.path.join(repo, 'cluster/addons', file)
+    with open(source, "r") as f:
+        content = f.read()
+    # LP 1822761: bump default influxdb container memory
+    content = content.replace("memory: 500M", "memory: 800M")
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def patch_metrics_server(repo, file):
     # nuke GKE specific stuff
     source = os.path.join(repo, 'cluster/addons', file)
@@ -314,6 +324,7 @@ def get_addon_templates():
         patch_heapster_controller(repo, influxdb + "/heapster-controller.yaml")
         add_addon(repo, influxdb + "/heapster-controller.yaml", dest)
         add_addon(repo, influxdb + "/heapster-service.yaml", dest)
+        patch_influxdb_grafana(repo, influxdb + "/influxdb-grafana-controller.yaml")
         add_addon(repo, influxdb + "/influxdb-grafana-controller.yaml", dest)
         add_addon(repo, influxdb + "/influxdb-service.yaml", dest)
 


### PR DESCRIPTION
Per https://bugs.launchpad.net/cdk-addons/+bug/1822761

Bump the default influxdb container memory from 500 to 800M.  This is a stop-gap to solve an immediate influxdb issue.  The larger solution will be to allow customization of cdkaddons templates post-deploy.