### PR TITLE
add all template images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 BUILD=build
-KUBE_ADDONS=addon-resizer coredns csi-attacher csi-node-driver-registrar csi-provisioner csi-snapshotter defaultbackend heapster k8s-dns k8s-keystone-auth kubernetes-dashboard metrics-server rbdplugin
 KUBE_ARCH=amd64
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
@@ -40,7 +39,7 @@ prep: clean
 	mv templates ${BUILD}
 
 upstream-images: prep
-	$(eval RAW_IMAGES := "$(foreach raw,${KUBE_ADDONS},$(shell grep -hoE 'image:.*${raw}.*' ./${BUILD}/templates/*.yaml | sort -u))")
+	$(eval RAW_IMAGES := "$(shell grep -hoE 'image:.*' ./${BUILD}/templates/* | sort -u)")
 # NB: sed cleans up image prefix/arch/quotes and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
 	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ arch }}/${KUBE_ARCH}/g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -237,8 +237,8 @@ def patch_keystone_deployment(repo, file):
     # :-/ Would be nice to be able to add this template a different way
     with open(source, "r") as f:
         content = f.read()
-    content = content.replace('image: k8scloudprovider/k8s-keystone-auth',
-                              'image: {{ registry|default("docker.io") }}/k8scloudprovider/k8s-keystone-auth')
+    content = content.replace("image: k8scloudprovider/k8s-keystone-auth",
+                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/k8s-keystone-auth")
     content = content.replace("            - --keystone-url",
                               """{% if keystone_server_ca %}
             - --keystone-ca-file
@@ -271,10 +271,10 @@ def patch_openstack_ccm(repo, file):
 def patch_openstack_registries(repo, file):
     source = Path(repo) / file
     content = source.read_text()
-    content = content.replace('image: docker.io/k8scloudprovider/',
-                              'image: {{ registry|default("docker.io") }}/k8scloudprovider/')
-    content = content.replace('image: quay.io/k8scsi/',
-                              'image: {{ registry|default("quay.io") }}/k8scsi/')
+    content = content.replace("image: docker.io/k8scloudprovider/",
+                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/")
+    content = content.replace("image: quay.io/k8scsi/",
+                              "image: {{ registry|default('quay.io') }}/k8scsi/")
     source.write_text(content)
 
 


### PR DESCRIPTION
- csi and keystone-auth images are provided by addons; include them in our list of upstream images
- consistently quote default registry locations for template replacements (single vs double make `sort -u` miss duplicates)
- handle inconsistent registry quoting in upstream-images target by stripping all quotes from the output