### PR TITLE
add all template images (#125)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 BUILD=build
-KUBE_ADDONS=addon-resizer coredns defaultbackend heapster k8s-dns kubernetes-dashboard metrics-server
 KUBE_ARCH=amd64
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable-1.14.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
@@ -37,9 +36,9 @@ prep: clean
 	mv templates ${BUILD}
 
 upstream-images: prep
-	$(eval RAW_IMAGES := "$(foreach raw,${KUBE_ADDONS},$(shell grep -hoE 'image:.*${raw}.*' ./${BUILD}/templates/*.yaml | sort -u))")
-# NB: sed cleans up image prefix/arch and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with a default registry
-	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ arch }}/${KUBE_ARCH}/g" -e "s/\{\{ registry\|default\('([^}]*)'\) }}/\1/g"))
+	$(eval RAW_IMAGES := "$(shell grep -hoE 'image:.*' ./${BUILD}/templates/* | sort -u)")
+# NB: sed cleans up image prefix/arch/quotes and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
+	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ arch }}/${KUBE_ARCH}/g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
 
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -237,8 +237,8 @@ def patch_keystone_deployment(repo, file):
     # :-/ Would be nice to be able to add this template a different way
     with open(source, "r") as f:
         content = f.read()
-    content = content.replace('image: k8scloudprovider/k8s-keystone-auth',
-                              'image: {{ registry|default("k8scloudprovider") }}/k8s-keystone-auth') # noqa
+    content = content.replace("image: k8scloudprovider/k8s-keystone-auth",
+                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/k8s-keystone-auth")
     content = content.replace("            - --keystone-url",
                               """{% if keystone_server_ca %}
             - --keystone-ca-file
@@ -271,10 +271,10 @@ def patch_openstack_ccm(repo, file):
 def patch_openstack_registries(repo, file):
     source = Path(repo) / file
     content = source.read_text()
-    content = content.replace('image: docker.io/k8scloudprovider/',
-                              'image: {{ registry|default("docker.io/k8scloudprovider") }}/')
-    content = content.replace('image: quay.io/k8scsi/',
-                              'image: {{ registry|default("quay.io/k8scsi") }}/')
+    content = content.replace("image: docker.io/k8scloudprovider/",
+                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/")
+    content = content.replace("image: quay.io/k8scsi/",
+                              "image: {{ registry|default('quay.io') }}/k8scsi/")
     source.write_text(content)
 
 


### PR DESCRIPTION
Backport #125 to 1.14 so we get all images known by cdk-addons-1.14 templates into our registry.

Note, this alters the keystone and openstack image locations with a `./k8scloudprovider` and `./k8scsi`. These prefixes match what we expect in the canonical registry.  However, existing deployments with a private registry may have to re-tag these images to include the prefixes.