### PR TITLE
Fix failure to apply kube-dns on k8s 1.15

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -30,7 +30,8 @@ def render_templates():
         "arch": get_snap_config("arch"),
         "pillar": {
             "dns_domain": get_snap_config("dns-domain"),
-            "num_nodes": node_count
+            "num_nodes": node_count,
+            "dns_memory_limit": "170Mi"
         },
         # nanny_memory for heapster
         # formula from https://github.com/kubernetes/kubernetes/blob/v1.9.6/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml#L11


### PR DESCRIPTION
This should fix the following error:

```
error validating "/root/snap/cdk-addons/911/addons/kube-dns.yaml": error validating data: unknown object type "nil" in Deployment.spec.template.spec.containers[0].resources.limits.memory
```

This was caused by an upstream change to the kube-dns template, which we pick up in k8s 1.15 builds: https://github.com/kubernetes/kubernetes/commit/59af63c687233c486cf2af18ca9c654dae98a43f#diff-d596e0f42eba97cd716ea636317f0d6aL109