### PR TITLE
add workaround for registries that do not support multi-arch images

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -17,6 +17,9 @@ dns_providers = {
     'kube-dns': 'kube-dns.yaml'
 }
 
+# Known registries that do not support multi-arch image manifests.
+single_arch_registries = ['image-registry.canonical.com']
+
 def main():
     if render_templates():
         apply_addons()
@@ -47,12 +50,20 @@ def render_templates():
         "base_metrics_server_cpu": "40m",
         "base_metrics_server_memory": "40Mi",
         "metrics_server_memory_per_node": "4",
-        "metrics_server_min_cluster_size": "16"
+        "metrics_server_min_cluster_size": "16",
+
+        # may need to hack image names if our registry doesn't support multi-arch images
+        "multiarch_workaround": ""
     }
 
     registry = get_snap_config("registry", required=False)
     if registry:
         context["registry"] = registry
+
+        for arch_reg in single_arch_registries:
+            if arch_reg in registry:
+                context["multiarch_workaround"] = "-{}".format(context["arch"])
+                break
 
     rendered = False
     dns_provider = get_snap_config("dns-provider")

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -302,8 +302,9 @@ def patch_coredns(repo, file):
     # will stay the same on its own.
     content = content.replace("clusterIP: CLUSTER_DNS_IP", "#clusterIP: CLUSTER_DNS_IP")
     # Make sure we're on CoreDNS 1.5.1.
-    content = content.replace("image: coredns/coredns:1.5.0",
-                              "image: {{ registry|default('docker.io') }}/coredns/coredns:1.5.1")
+    content = content.replace(
+        "image: coredns/coredns:1.5.0",
+        "image: {{ registry|default('docker.io') }}/coredns/coredns{{ multiarch_workaround }}:1.5.1")
     with open(source, "w") as f:
         f.write(content)
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -309,6 +309,25 @@ def patch_coredns(repo, file):
         f.write(content)
 
 
+def patch_kubedns(repo, file):
+    source = os.path.join(repo, file)
+    with open(source, "r") as f:
+        content = f.read()
+    # Inject our hacky multiarch workaround until our registry supports fat manifests:
+    # https://github.com/charmed-kubernetes/cdk-addons/pull/130
+    content = content.replace(
+        "image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13",
+        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-kube-dns{{ multiarch_workaround }}:1.14.13")
+    content = content.replace(
+        "image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13",
+        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-dnsmasq-nanny{{ multiarch_workaround }}:1.14.13")
+    content = content.replace(
+        "image: k8s.gcr.io/k8s-dns-sidecar:1.14.13",
+        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-sidecar{{ multiarch_workaround }}:1.14.13")
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def get_addon_templates():
     """ Get addon templates. This will clone the kubernetes repo from upstream
     and copy addons to ./templates """
@@ -317,6 +336,7 @@ def get_addon_templates():
     with kubernetes_repo() as repo:
         log.info("Copying addons to " + dest)
 
+        patch_kubedns(repo, "dns/kube-dns/kube-dns.yaml.in")
         add_addon(repo, "dns/kube-dns/kube-dns.yaml.in", dest + "/kube-dns.yaml")
 
         influxdb = "cluster-monitoring/influxdb"


### PR DESCRIPTION
Partial fix for https://github.com/charmed-kubernetes/jenkins/issues/445.  The rest will happen on the jenkins side, when images are actually pushed to the canonical registry.