### PR TITLE
leave {{arch}} in the image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ prep: clean
 
 upstream-images: prep
 	$(eval RAW_IMAGES := "$(shell grep -hoE 'image:.*' ./${BUILD}/templates/* | sort -u)")
-# NB: sed cleans up image prefix/arch/quotes and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
-	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ arch }}/${KUBE_ARCH}/g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
+# NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
+	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
 
 


### PR DESCRIPTION
We want to leave `{{ arch }}` in the image name.  Otherwise, we end up with a static arch string for whatever job last pushed `container-images.txt`:

https://github.com/charmed-kubernetes/bundle/commit/86309ba9f4169c774628e1a4cf56ab49bb552c12

Example from above: `k8s.gcr.io/metrics-server-arm64:v0.3.3` is the way it is because cdk-addons/arm64 was the last job to run.  The only consumer of the `upstream-images` target is our jenkins job, and it already knows to substitute the right arch:

https://github.com/charmed-kubernetes/jenkins/blob/master/jobs/build-snaps/build-release-cdk-addons.groovy#L131

By leaving `{{arch}}` in the image name, consumers of `container-images.txt` will know to substitute whatever arch they care about.