### PR TITLE
sub metrics-server version for one that works across all arches

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -199,12 +199,15 @@ def patch_influxdb_grafana(repo, file):
 
 
 def patch_metrics_server(repo, file):
-    # nuke GKE specific stuff
     source = os.path.join(repo, 'cluster/addons', file)
     with open(source, "r") as f:
         content = f.read()
+    # nuke GKE specific stuff
     content = content.replace("- --kubelet-port=10255", "# - --kubelet-port=10255")
     content = content.replace("- --deprecated-kubelet-completely-insecure=true", "# - --deprecated-kubelet-completely-insecure=true")
+    # use v0.3.2 until latest (0.3.3) images are available for alt arches, eg:
+    # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-s390x?gcrImageListsize=30
+    content = content.replace("v0.3.3", "v0.3.2")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
k8s 1.15 moved the metrics-server image up to v0.3.3 for amd64.  That image doesn't exist for our alt arches, e.g.:

https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-arm64?gcrImageListsize=30

Normally, we pin specific commits to keep an image version at something we know to be good.  We can't do that for the metrics-server because it comes as part of the larger kubernetes/cluster/addons pull from the k8s repo, and pinning a v0.3.2 commit would hold the entire repo at that old commit.

So instead, we effectively revert https://github.com/kubernetes/kubernetes/commit/454460f875145763d5b5b37a1b4eb5198de71080#diff-4ffb1b3cd8dee2a34a93e834d2b2b385 with a global substitution.

