### PR TITLE
Add cdk-restart-on-ca-change label to addons

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -192,6 +192,8 @@ def render_template(file, context, required=True, render_filename=None):
     for part in data:
         part["metadata"].setdefault("labels", {})
         part["metadata"]["labels"]["cdk-addons"] = "true"
+        if part["kind"] in ["Deployment", "DaemonSet", "StatefulSet"]:
+           part["metadata"]["labels"]["cdk-restart-on-ca-change"] = "true"
     content = yaml.dump_all(data)
 
     with open(dest, "w") as f:


### PR DESCRIPTION
Required by https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/34

Part of fixing https://bugs.launchpad.net/cdk-addons/+bug/1809377

This adds a new label, `cdk-restart-on-ca-change`, which is used by kubernetes-master to select addons to restart when the cluster CA changes.