### PR TITLE
[1.13] Add cdk-restart-on-ca-change label to addons

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -186,6 +186,8 @@ def render_template(file, context, required=True, render_filename=None):
     for part in data:
         part["metadata"].setdefault("labels", {})
         part["metadata"]["labels"]["cdk-addons"] = "true"
+        if part["kind"] in ["Deployment", "DaemonSet", "StatefulSet"]:
+           part["metadata"]["labels"]["cdk-restart-on-ca-change"] = "true"
     content = yaml.dump_all(data)
 
     with open(dest, "w") as f:


### PR DESCRIPTION
Required by https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/34

Part of fixing https://bugs.launchpad.net/cdk-addons/+bug/1809377

Cherry-pick of https://github.com/charmed-kubernetes/cdk-addons/pull/133