### PR TITLE
Add volumeBindingMode option to AWS storage class for Juju

### DIFF
--- a/bundled-templates/storageclass-aws.yaml
+++ b/bundled-templates/storageclass-aws.yaml
@@ -7,3 +7,4 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Juju wants the binding mode to be deferred, which is actually a better default.