### PR TITLE
Update get-addon-templates

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -449,7 +449,7 @@ def get_addon_templates():
         add_addon(repo, "kubernetes/coredns.yaml.sed", dest + "/core-dns.yaml", base='.')
 
     for template in Path('bundled-templates').iterdir():
-        shutil.copy2(template, dest)
+        shutil.copy2(str(template), dest)
 
 
 def parse_args():


### PR DESCRIPTION
cast PosixPath as string when passing to shutil.copy2. It looks like python3.6 supports passing a PosixPath and `shutil.copy2` will jdrt, however, we don't state what the minimum python version to use here `#!/usr/bin/env python3` and on systems with multiple python versions installed (ie jenkins) it could potentionally pick an unsupported python version (python3.5). This should fix the compatibility issues seen on Jenkins.