### PR TITLE
Update CoreDNS and Ceph CSI for 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ PWD=$(shell pwd)
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-# NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
-# https://github.com/ceph/ceph-csi/issues/278
-CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
+CEPH_CSI_COMMIT=c7ba26d23d784f7e21d850c6d014897f25a9868d
 COREDNS_COMMIT=8fb8871a309cc77baaef27f5b227ec0e546daf0c
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PWD=$(shell pwd)
 # NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
-COREDNS_COMMIT=d26b5fbfcb53eba71a9a0f827eebea483d6becd7
+COREDNS_COMMIT=8fb8871a309cc77baaef27f5b227ec0e546daf0c
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9
 KUBE_DASHBOARD_VERSION=v1.10.1

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -106,13 +106,16 @@ def render_templates():
             "ceph-admin-key", required=True)
         ceph_context['kubernetes_key'] = get_snap_config(
             "ceph-kubernetes-key", required=True)
-        ceph_context['mon_hosts'] = get_snap_config(
-            "ceph-mon-hosts", required=True)
+        mon_hosts = get_snap_config("ceph-mon-hosts", required=True)
+        ceph_context['ceph_csi_config_data'] = json.dumps([{
+            'clusterID': 'charmed-kubernetes',
+            'monitors': mon_hosts.split(',')
+        }])
 
         render_template("ceph-secret.yaml", ceph_context)
+        render_template("csi-config-map.yaml", ceph_context)
         render_template("csi-rbdplugin.yaml", ceph_context)
         render_template("csi-rbdplugin-provisioner.yaml", ceph_context)
-        render_template("csi-rbdplugin-attacher.yaml", ceph_context)
 
         ext4_context = ceph_context.copy()
         if default_storage == 'ceph-ext4':
@@ -137,7 +140,6 @@ def render_templates():
         render_template("ceph-storageclass.yaml", xfs_context,
                         render_filename="ceph-xfs-storageclass.yaml")
         # RBAC
-        render_template("csi-attacher-rbac.yaml", ceph_context)
         render_template("csi-nodeplugin-rbac.yaml", ceph_context)
         render_template("csi-provisioner-rbac.yaml", ceph_context)
         rendered = True

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -147,21 +147,30 @@ def patch_plugin_manifest(repo, file):
 def patch_ceph_secret(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
-        manifest = yaml.load(stream)
-    manifest['data']['admin'] = "{{ admin_key }}"
-    manifest['data']['kubernetes'] = "{{ kubernetes_key }}"
+        manifest = yaml.safe_load(stream)
+    manifest['stringData']['userID'] = 'admin'
+    del manifest['stringData']['userKey']
+    manifest.setdefault('data', {})['userKey'] = '{{ admin_key }}'
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
+
+
+def patch_ceph_config_map(repo, file):
+    source = os.path.join(repo, file)
+    with open(source) as f:
+        content = f.read()
+    content = content.replace("    []", "    {{ ceph_csi_config_data }}")
+    with open(source, 'w') as f:
+        f.write(content)
 
 
 def patch_ceph_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['parameters']['monitors'] = "{{ mon_hosts }}"
+    manifest['parameters']['clusterID'] = 'charmed-kubernetes'
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['fsType'] = "{{ fs_type }}"
-    manifest['parameters']['userid'] = "admin"
     manifest['metadata']['name'] = "{{ sc_name }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
@@ -399,21 +408,19 @@ def get_addon_templates():
 
     with ceph_csi_repo() as repo:
         log.info("Copying ceph CSI templates to " + dest)
-        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", {"app": "csi-rbdplugin-provisioner"})
-        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", {"app": "csi-rbdplugin-attacher"})
-        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", {"app": "csi-rbdplugin"})
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
-        add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
 
         patch_ceph_secret(repo, "examples/rbd/secret.yaml")
         add_addon(repo, "examples/rbd/secret.yaml", os.path.join(dest, "ceph-secret.yaml"), base='.')
 
+        patch_ceph_config_map(repo, 'deploy/rbd/kubernetes/csi-config-map.yaml')
+        add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
+
         patch_ceph_storage_class(repo, "examples/rbd/storageclass.yaml")
         add_addon(repo, "examples/rbd/storageclass.yaml", os.path.join(dest, "ceph-storageclass.yaml"), base='.')
 
         # rbac templates
-        add_addon(repo, "deploy/rbd/kubernetes/csi-attacher-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-provisioner-rbac.yaml", dest, base='.')
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -305,10 +305,9 @@ def patch_coredns(repo, file):
     # Let Kubernetes handle the service IP. When upgrading from kube-dns it
     # will stay the same on its own.
     content = content.replace("clusterIP: CLUSTER_DNS_IP", "#clusterIP: CLUSTER_DNS_IP")
-    # Make sure we're on CoreDNS 1.5.1.
     content = content.replace(
-        "image: coredns/coredns:1.5.0",
-        "image: {{ registry|default('docker.io') }}/coredns/coredns{{ multiarch_workaround }}:1.5.1")
+        "image: coredns/coredns",
+        "image: {{ registry|default('docker.io') }}/coredns/coredns{{ multiarch_workaround }}")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1841838

* Updated CoreDNS to 1.6.2, which is the version that upstream will ship with k8s 1.16 ([source](https://github.com/kubernetes/kubernetes/blob/34ba9e74d5867d540b859443fae087b176389fe8/cmd/kubeadm/app/constants/constants.go#L336)).
* Updated Ceph CSI to 1.1.0, which is the latest version ([source](https://github.com/ceph/ceph-csi/releases)).
* Checked kubernetes-dashboard, no new stable versions ([source](https://github.com/kubernetes/dashboard/releases)).
* Skipped cloud-provider-openstack since I don't feel confident in our ability to test updates to that quickly.

I tested using a local [bundle.yaml](https://gist.github.com/Cynerva/4ab2bd141b694dc5b9d6dcbdf67112d1) that includes components from this PR along with [charm-kubernetes-worker#33](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/33) and [charm-flannel#56](https://github.com/charmed-kubernetes/charm-flannel/pull/56). I deployed the bundle and ran validation with "slow" tests skipped:
```
$ pytest -s --no-print-logs -m "not slow" validation.py --controller aws-dev --model test2
...
Results (937.29s):
      16 passed
       4 skipped
       1 deselected
```

I manually tested Ceph CSI by adding Ceph to the deployment as documented [here](https://ubuntu.com/kubernetes/docs/storage). I created a PersistentVolumeClaim using the ceph-xfs StorageClass, created a Pod that uses the PVC, wrote data to the persistent volume, destroyed the pod, created a new pod on a different worker, and confirmed that the new pod could read the data that was previously written. I also confirmed that the PVC deletes cleanly and that none of the Ceph CSI components logged any errors throughout this whole process.