### PR TITLE
Revert "Update to Ceph CSI 1.1.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ PWD=$(shell pwd)
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-CEPH_CSI_COMMIT=c7ba26d23d784f7e21d850c6d014897f25a9868d
+# NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
+# https://github.com/ceph/ceph-csi/issues/278
+CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=8fb8871a309cc77baaef27f5b227ec0e546daf0c
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -106,16 +106,13 @@ def render_templates():
             "ceph-admin-key", required=True)
         ceph_context['kubernetes_key'] = get_snap_config(
             "ceph-kubernetes-key", required=True)
-        mon_hosts = get_snap_config("ceph-mon-hosts", required=True)
-        ceph_context['ceph_csi_config_data'] = json.dumps([{
-            'clusterID': 'charmed-kubernetes',
-            'monitors': mon_hosts.split(',')
-        }])
+        ceph_context['mon_hosts'] = get_snap_config(
+            "ceph-mon-hosts", required=True)
 
         render_template("ceph-secret.yaml", ceph_context)
-        render_template("csi-config-map.yaml", ceph_context)
         render_template("csi-rbdplugin.yaml", ceph_context)
         render_template("csi-rbdplugin-provisioner.yaml", ceph_context)
+        render_template("csi-rbdplugin-attacher.yaml", ceph_context)
 
         ext4_context = ceph_context.copy()
         if default_storage == 'ceph-ext4':
@@ -140,6 +137,7 @@ def render_templates():
         render_template("ceph-storageclass.yaml", xfs_context,
                         render_filename="ceph-xfs-storageclass.yaml")
         # RBAC
+        render_template("csi-attacher-rbac.yaml", ceph_context)
         render_template("csi-nodeplugin-rbac.yaml", ceph_context)
         render_template("csi-provisioner-rbac.yaml", ceph_context)
         rendered = True

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -147,30 +147,21 @@ def patch_plugin_manifest(repo, file):
 def patch_ceph_secret(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
-        manifest = yaml.safe_load(stream)
-    manifest['stringData']['userID'] = 'admin'
-    del manifest['stringData']['userKey']
-    manifest.setdefault('data', {})['userKey'] = '{{ admin_key }}'
+        manifest = yaml.load(stream)
+    manifest['data']['admin'] = "{{ admin_key }}"
+    manifest['data']['kubernetes'] = "{{ kubernetes_key }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
-
-
-def patch_ceph_config_map(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as f:
-        content = f.read()
-    content = content.replace("    []", "    {{ ceph_csi_config_data }}")
-    with open(source, 'w') as f:
-        f.write(content)
 
 
 def patch_ceph_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['parameters']['clusterID'] = 'charmed-kubernetes'
+    manifest['parameters']['monitors'] = "{{ mon_hosts }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['fsType'] = "{{ fs_type }}"
+    manifest['parameters']['userid'] = "admin"
     manifest['metadata']['name'] = "{{ sc_name }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
@@ -408,19 +399,21 @@ def get_addon_templates():
 
     with ceph_csi_repo() as repo:
         log.info("Copying ceph CSI templates to " + dest)
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", {"app": "csi-rbdplugin-provisioner"})
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", {"app": "csi-rbdplugin-attacher"})
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", {"app": "csi-rbdplugin"})
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
+        add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
 
         patch_ceph_secret(repo, "examples/rbd/secret.yaml")
         add_addon(repo, "examples/rbd/secret.yaml", os.path.join(dest, "ceph-secret.yaml"), base='.')
 
-        patch_ceph_config_map(repo, 'deploy/rbd/kubernetes/csi-config-map.yaml')
-        add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
-
         patch_ceph_storage_class(repo, "examples/rbd/storageclass.yaml")
         add_addon(repo, "examples/rbd/storageclass.yaml", os.path.join(dest, "ceph-storageclass.yaml"), base='.')
 
         # rbac templates
+        add_addon(repo, "deploy/rbd/kubernetes/csi-attacher-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-provisioner-rbac.yaml", dest, base='.')
 


### PR DESCRIPTION
This reverts commit fc675ced56a9e231e428dd9c28fff370b8095eca.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1842706
Related to https://bugs.launchpad.net/cdk-addons/+bug/1841838

Upgrading to Ceph CSI v1.1.0 breaks a couple things that I didn't find in initial testing. See issues for detail. We need to revert back to v1.0.0 because we really don't have time to be working through issues like this right now.

Lightly tested by upgrading an existing CK 1.16 cluster to cdk-addons built from this branch, and confirming that it cleanly deployed the correct version of Ceph CSI. I did not run validation or do any other extensive testing.