### PR TITLE
Replace addon-resizer image for arm64/s390x support

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -108,13 +108,10 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         content = f.read()
     content = content.replace("amd64", "{{ arch }}")
     content = content.replace("clusterIP: {{ pillar['dns_server'] }}", "# clusterIP: {{ pillar['dns_server'] }}")
-    content = content.replace(
-        "gcr.io/google_containers/addon-resizer:1.8.1",
-        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
-    )
-    content = content.replace(
-        "k8s.gcr.io/addon-resizer:1.8.1",
-        "cdkbot/addon-resizer-{{ arch }}:1.8.1"
+    content = re.sub(
+        r'(image:.*)addon-resizer:1\..*',
+        r"image: {{ registry|default('rocks.canonical.com/cdk') }}/addon-resizer-{{ arch }}:1.8.5",
+        content
     )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1841729

Tested by deploying charmed-kubernetes from edge with the modified cdk-addons snap attached. I did this for both amd64 and arm64. In both deployments, I verified that the correct addon-resizer image was used, the addon-resizer containers were running, and the addon-resizer containers were logging reasonable output.

I also verified that the default registry handling works, by configuring kubernetes-master with `image-registry=""` and repeating the earlier checks.