### PR TITLE
Support volume configuration for influxdb/grafana (cont)

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -54,7 +54,7 @@ def render_templates():
         "base_metrics_server_memory": "40Mi",
         "metrics_server_memory_per_node": "4",
         "metrics_server_min_cluster_size": "16",
-        "monitorstorage": get_snap_config("monitorstorage")
+        "monitorstorage": get_snap_config("monitorstorage"),
 
         # may need to hack image names if our registry doesn't support multi-arch images
         "multiarch_workaround": ""

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -54,6 +54,7 @@ def render_templates():
         "base_metrics_server_memory": "40Mi",
         "metrics_server_memory_per_node": "4",
         "metrics_server_min_cluster_size": "16",
+        "monitorstorage": get_snap_config("monitorstorage")
 
         # may need to hack image names if our registry doesn't support multi-arch images
         "multiarch_workaround": ""
@@ -81,7 +82,12 @@ def render_templates():
             # default to basic auth as it used to be hard-coded
             dash_context['dashboard_auth'] = 'basic'
         render_template("kubernetes-dashboard.yaml", dash_context)
-        render_template("influxdb-grafana-controller.yaml", dash_context)
+        # monitorstorage
+        dash_ig_context = dash_context.copy()
+        dash_ig_context['monitorstorage'] = list(yaml.load_all(dash_ig_context['monitorstorage']))[0]
+        dash_ig_context['monitorstorage']['influxdb'] = yaml.dump(dash_ig_context['monitorstorage']['influxdb'])
+        dash_ig_context['monitorstorage']['grafana'] = yaml.dump(dash_ig_context['monitorstorage']['grafana'])
+        render_template("influxdb-grafana-controller.yaml", dash_ig_context)
         render_template("influxdb-service.yaml", dash_context)
         render_template("grafana-service.yaml", dash_context)
         render_template("heapster-rbac.yaml", dash_context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -10,6 +10,7 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            default-storage enable-ceph enable-keystone keystone-server-url \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
-           openstack-endpoint-ca enable-aws enable-azure enable-gcp; do
+           openstack-endpoint-ca enable-aws enable-azure enable-gcp \
+           monitorstorage; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -194,6 +194,15 @@ def patch_influxdb_grafana(repo, file):
         content = f.read()
     # LP 1822761: bump default influxdb container memory
     content = content.replace("memory: 500M", "memory: 800M")
+    content = content.replace("volumes:\n\
+      - name: influxdb-persistent-storage\n\
+        emptyDir: {}\n\
+      - name: grafana-persistent-storage\n\
+        emptyDir: {}","volumes:\n\
+      - name: influxdb-persistent-storage\n\
+        {{ monitorstorage['influxdb'] }}\n\
+      - name: grafana-persistent-storage\n\
+        {{ monitorstorage['grafana'] }}")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1830118 for cdk-addons

Continuation of https://github.com/charmed-kubernetes/cdk-addons/pull/141 (thanks @xtrusia!)

I've reviewed the first commit. In the second commit, I added a comma. Somebody review my comma.

I tested this by deploying charmed-kubernetes, with kubernetes-master built from [charm-kubernetes-master#52](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/52), and cdk-addons built and attached from this PR.

I confirmed that with default configuration and no persistent storage, Grafana still works, but doesn't persist data when the pod is migrated to another node.

I added ceph to the cluster and created two PersistentVolumeClaims:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: influxdb
  namespace: kube-system
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi
  storageClassName: ceph-xfs
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: grafana
  namespace: kube-system
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 1Gi
  storageClassName: ceph-xfs
```

Configured monitoring-storage to use them:
```
$ juju config kubernetes-master monitoring-storage="
influxdb:
  persistentVolumeClaim:
    claimName: influxdb
grafana:
  persistentVolumeClaim:
    claimName: grafana
"
```

Then checked grafana again. This time, when I killed the influxdb-grafana pod and forced it to migrate to a new node, the data was preserved.