### PR TITLE
Add cluster-tag config and pass through to OpenStack CCM

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -56,7 +56,10 @@ def render_templates():
         "metrics_server_min_cluster_size": "16",
 
         # may need to hack image names if our registry doesn't support multi-arch images
-        "multiarch_workaround": ""
+        "multiarch_workaround": "",
+
+        # let addons know what we're calling our cluster
+        "cluster_tag": get_snap_config("cluster-tag", required=False),
     }
 
     registry = get_snap_config("registry", required=False)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -10,6 +10,7 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            default-storage enable-ceph enable-keystone keystone-server-url \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
-           openstack-endpoint-ca enable-aws enable-azure enable-gcp; do
+           openstack-endpoint-ca enable-aws enable-azure enable-gcp \
+           cluster-tag; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -269,6 +269,11 @@ def patch_openstack_ccm(repo, file):
     content = source.read_text()
     content = content.replace('      nodeSelector:\n'
                               '        node-role.kubernetes.io/master: ""\n', '')
+    content = content.replace('          args:\n'
+                              '            - /bin/openstack-cloud-controller-manager\n',
+                              '          args:\n'
+                              '            - /bin/openstack-cloud-controller-manager\n'
+                              '            - --cluster-name={{ cluster_tag }}\n')
     source.write_text(content)
 
 


### PR DESCRIPTION
The `--cluster-name` arg for the Cloud Controller Manager is used as a prefix to load balancers created by Kubernetes. If it is not set, it defaults to `kubernetes` leading to collisions with other clusters. This uses the cluster tag created by the charms to ensure uniqueness.

Fixes [lp:1842941](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1842941)