### PR TITLE
Include missed templates for OpenStack CCM to support RBAC

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -212,13 +212,21 @@ def render_template(file, context, required=True, render_filename=None):
         template = Template(f.read())
     content = template.render(context)
 
-    # apply cdk-addons=true label
-    data = [part for part in yaml.load_all(content) if part]
-    for part in data:
+    def _add_labels(part):
         part["metadata"].setdefault("labels", {})
         part["metadata"]["labels"]["cdk-addons"] = "true"
         if part["kind"] in ["Deployment", "DaemonSet", "StatefulSet"]:
-           part["metadata"]["labels"]["cdk-restart-on-ca-change"] = "true"
+            part["metadata"]["labels"]["cdk-restart-on-ca-change"] = "true"
+
+    # apply cdk-addons=true label
+    data = [part for part in yaml.load_all(content) if part]
+    for part in data:
+        if part['kind'] == 'List':
+            # some files use kind:List rather than a set of YAML parts
+            for item in part['items']:
+                _add_labels(item)
+        else:
+            _add_labels(part)
     content = yaml.dump_all(data)
 
     with open(dest, "w") as f:

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -177,6 +177,8 @@ def render_templates():
             "endpoint_ca_cert": get_snap_config("openstack-endpoint-ca", required=False),
         })
 
+        render_template("cloud-controller-manager-roles.yaml", openstack_context)
+        render_template("cloud-controller-manager-role-bindings.yaml", openstack_context)
         render_template("openstack-cloud-controller-manager-ds.yaml", openstack_context)
         render_template("cloud-config-secret.yaml", openstack_context)
 
@@ -253,6 +255,17 @@ def prune_addons():
     Instead of using that, we just have to do it ourselves.
     '''
     current_addons = set()
+
+    def _include_addon(part):
+        kind = part['kind']
+        # If no namespace is specified, it's either an unnamespaced
+        # resource, or a namespaced resource that will end up in
+        # 'default'. We can delete both in the same way so we may
+        # as well put them in the same bucket.
+        namespace = part['metadata'].get('namespace', 'default')
+        name = part['metadata']['name']
+        current_addons.add((kind, namespace, name))
+
     for root, _, filenames in os.walk(addon_dir):
         for filename in filenames:
             path = os.path.join(root, filename)
@@ -260,13 +273,13 @@ def prune_addons():
                 data = yaml.load_all(f)
                 for part in data:
                     kind = part['kind']
-                    # If no namespace is specified, it's either an unnamespaced
-                    # resource, or a namespaced resource that will end up in
-                    # 'default'. We can delete both in the same way so we may
-                    # as well put them in the same bucket.
-                    namespace = part['metadata'].get('namespace', 'default')
-                    name = part['metadata']['name']
-                    current_addons.add((kind, namespace, name))
+                    if kind == 'List':
+                        # yaml is a single kind:List instead of joined yaml parts
+                        for item in part['items']:
+                            _include_addon(item)
+                    else:
+                        # yaml is a set of joined parts
+                        _include_addon(part)
 
     output = kubectl(
         'get',

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -445,6 +445,8 @@ def get_addon_templates():
 
         add_addon(repo, "manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml", dest, base='.')
         add_addon(repo, "manifests/controller-manager/cloud-config-secret.yaml", dest, base='.')
+        add_addon(repo, "cluster/addons/rbac/cloud-controller-manager-role-bindings.yaml", dest, base='.')
+        add_addon(repo, "cluster/addons/rbac/cloud-controller-manager-roles.yaml", dest, base='.')
 
         patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml")
         patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml")

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -279,7 +279,8 @@ def patch_openstack_ccm(repo, file):
                               '            - /bin/openstack-cloud-controller-manager\n',
                               '          args:\n'
                               '            - /bin/openstack-cloud-controller-manager\n'
-                              '            - --cluster-name={{ cluster_tag }}\n')
+                              '            - --cluster-name={{ cluster_tag }}\n'
+                              '            - --authentication-skip-lookup=true\n')
     source.write_text(content)
 
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -279,8 +279,7 @@ def patch_openstack_ccm(repo, file):
                               '            - /bin/openstack-cloud-controller-manager\n',
                               '          args:\n'
                               '            - /bin/openstack-cloud-controller-manager\n'
-                              '            - --cluster-name={{ cluster_tag }}\n'
-                              '            - --authentication-skip-lookup=true\n')
+                              '            - --cluster-name={{ cluster_tag }}\n')
     source.write_text(content)
 
 


### PR DESCRIPTION
The OpenStack Cloud Controller Manager repo includes some additional manifests to handle RBAC-enabled clusters.  These got missed.

Fixes: [lp:1845231]

[lp:1845231]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1845231