### PR TITLE
Updating dashboard for 1.16 (#149)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=8fb8871a309cc77baaef27f5b227ec0e546daf0c
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9
-KUBE_DASHBOARD_VERSION=v1.10.1
+KUBE_DASHBOARD_VERSION=v2.0.0-beta4
 
 default: prep
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -113,6 +113,12 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         r"image: {{ registry|default('rocks.canonical.com/cdk') }}/addon-resizer-{{ arch }}:1.8.5",
         content
     )
+    # TODO: dashboard v2-b4 was needed late in the 1.16 release cycle. Once we verify
+    # rocks has a multi-arch manifest, stop forcing an -{{ arch }} string in the name.
+    content = content.replace(
+        "kubernetesui/dashboard:v2.0.0-beta4",
+        "kubernetesui/dashboard-{{ arch }}:v2.0.0-beta4"
+    )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",
                      "image: {{ registry|default('docker.io') }}/cdkbot/",
@@ -125,6 +131,9 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
                      content)
     content = re.sub(r"image:\s*quay.io/",
                      "image: {{ registry|default('quay.io') }}/",
+                     content)
+    content = re.sub(r"image:\s*kubernetesui/",
+                     "image: {{ registry|default('docker.io') }}/kubernetesui/",
                      content)
     with open(dest, "w") as f:
         f.write(content)
@@ -299,7 +308,7 @@ def patch_dashboard(repo, file):
         content = f.read()
     content = content.replace("- --auto-generate-certificates",
                               """- --auto-generate-certificates
-          - --authentication-mode={{ dashboard_auth }}""")
+            - --authentication-mode={{ dashboard_auth }}""")
     with open(source, "w") as f:
         f.write(content)
 
@@ -398,9 +407,9 @@ def get_addon_templates():
 
     with kubernetes_dashboard_repo() as repo:
         log.info("Copying dashboard to " + dest)
-        dashboard_yaml = "src/deploy/recommended/kubernetes-dashboard.yaml"
+        dashboard_yaml = 'aio/deploy/recommended.yaml'
         patch_dashboard(repo, dashboard_yaml)
-        add_addon(repo, dashboard_yaml, dest, base='.')
+        add_addon(repo, dashboard_yaml, os.path.join(dest, 'kubernetes-dashboard.yaml'), base='.')
 
     with nvidia_plugin_repo() as repo:
         log.info("Copying nvidia plugin to " + dest)


### PR DESCRIPTION
* Updating dashboard for 1.16

The last stable dashboard release does not work with k8s 1.16. The latest
beta is now being used, which is version 2.0.0-beta4. This works with
1.16, but requires a new URL to access. The PR for the docs change is
https://github.com/charmed-kubernetes/kubernetes-docs/pull/282

* set docker.io default registry; substitute image for $arch-specific images until a fat manifest is verified in rocks