### PR TITLE
Pin OpenStack provider to a release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PWD=$(shell pwd)
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=8fb8871a309cc77baaef27f5b227ec0e546daf0c
 # pin cloud-provider-openstack because it's under active dev
-OPENSTACK_PROVIDER_COMMIT=1b68bd85d5c6670a0b9aa0b7a4ef8934ef1b1eb9
+OPENSTACK_PROVIDER_COMMIT=release-1.15
 KUBE_DASHBOARD_VERSION=v2.0.0-beta4
 
 default: prep
@@ -43,6 +43,3 @@ upstream-images: prep
 # NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
 	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
-
-
-


### PR DESCRIPTION
By pinning to a release branch, we'll get manifests that contain release
tags (e.g. :v1.15.0) instead of :latest tags, ensuring that the images
deployed won't change for that build of cdk-addons.

The manifests/images affected are:
- cinder-csi-nodeplugin.yaml: k8scloudprovider/cinder-csi-plugin:v1.15.0
- cinder-csi-controllerplugin.yaml: k8scloudprovider/cinder-csi-plugin:v1.15.0
- openstack-cloud-controller-manager-ds.yaml: k8scloudprovider/openstack-cloud-controller-manager:v1.15.0

Fixes: https://bugs.launchpad.net/cdk-addons/+bug/1847799