### PR TITLE
Only set --cluster-name if value is provided

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -288,7 +288,7 @@ def patch_openstack_ccm(repo, file):
                               '            - /bin/openstack-cloud-controller-manager\n',
                               '          args:\n'
                               '            - /bin/openstack-cloud-controller-manager\n'
-                              '            - --cluster-name={{ cluster_tag }}\n')
+                              '{%- if cluster-tag %}            - --cluster-name={{ cluster_tag }}\n{% endif %}')
     source.write_text(content)
 
 


### PR DESCRIPTION
To ensure that the snap works with earlier versions of the charm code which do not send the `cluster-tag` config, we should only include the `--cluster-name` param if we have a value to give it. If the value is not provided, we leave off the option and allow it to fall back to the old behavior of using the upstream default.