### PR TITLE
Bumping influxdb memory limit to 1100 megs to prevent OOM kills

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -199,12 +199,12 @@ def patch_influxdb_grafana(repo, file):
     with open(source, "r") as f:
         content = f.read()
     # LP 1822761: bump default influxdb container memory
-    content = content.replace("memory: 500M", "memory: 800M")
+    content = content.replace("memory: 500M", "memory: 1100M")
     content = content.replace("volumes:\n\
       - name: influxdb-persistent-storage\n\
         emptyDir: {}\n\
       - name: grafana-persistent-storage\n\
-        emptyDir: {}","volumes:\n\
+        emptyDir: {}", "volumes:\n\
       - name: influxdb-persistent-storage\n\
         {{ monitorstorage['influxdb'] }}\n\
       - name: grafana-persistent-storage\n\


### PR DESCRIPTION
OOM kills were happening because the default config for influx allows
for 1 gig of cache. Hopefully, 100 megs is enough buffer for the other
things influx requires.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1844526

Tested on AWS with 1.16 and verified the updated memory showed in the pod description.