### PR TITLE
Fix cdk-cinder StorageClass getting recreated

### DIFF
--- a/bundled-templates/storageclass-openstack.yaml
+++ b/bundled-templates/storageclass-openstack.yaml
@@ -5,4 +5,3 @@ metadata:
   annotations:
     juju.io/workload-storage: "true"
 provisioner: csi-cinderplugin
-parameters: {}


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1851404

The empty parameters map is causing `kubectl apply` to think something has changed:

```
$ kubectl apply -f storageclass-openstack.yaml
The StorageClass "cdk-cinder" is invalid: parameters: Forbidden: updates to parameters are forbidden.
```

Removing the `parameters: {}` line restores correct behavior:

```
$ kubectl apply -f storageclass-openstack.yaml --force
storageclass.storage.k8s.io/cdk-cinder created
$ kubectl apply -f storageclass-openstack.yaml --force
storageclass.storage.k8s.io/cdk-cinder unchanged
$ kubectl apply -f storageclass-openstack.yaml --force
storageclass.storage.k8s.io/cdk-cinder unchanged
```

I have *not* tested this on OpenStack. I can however confirm that the StorageClass that gets created appears to be identical. I have also confirmed that none of the other StorageClasses in cdk-addons have the same problem.