### PR TITLE
Replacing images impacted by CVE 2019-11255

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -371,6 +371,18 @@ def patch_for_1_16(repo, file, selector):
         yaml.dump_all(manifest, yaml_file, default_flow_style=False)
 
 
+def patch_for_CVE_2019_11255(repo, file):
+    replace_images = [['/csi-provisioner:v1.0.1', '/csi-provisioner:v1.0.2'],
+                      ['/csi-snapshotter:v1.0.1', '/csi-snapshotter:v1.0.2']]
+    source = os.path.join(repo, file)
+    with open(source) as f:
+        content = f.read()
+    for i in replace_images:
+        content = content.replace(i[0], i[1])
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def get_addon_templates():
     """ Get addon templates. This will clone the kubernetes repo from upstream
     and copy addons to ./templates """
@@ -422,6 +434,7 @@ def get_addon_templates():
         patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", {"app": "csi-rbdplugin-provisioner"})
         patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", {"app": "csi-rbdplugin-attacher"})
         patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", {"app": "csi-rbdplugin"})
+        patch_for_CVE_2019_11255(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
@@ -458,6 +471,7 @@ def get_addon_templates():
 
         patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml")
         patch_openstack_registries(repo, "manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml")
+        patch_for_CVE_2019_11255(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml")
 
         add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml", dest, base='.')
         add_addon(repo, "manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml", dest, base='.')


### PR DESCRIPTION
Jumped version 1.0.1 of csi-provisioner and csi-snapshotter to 1.0.2

Tested with deploy of ceph on aws. Deployed two pods that required PV's and they were correctly created and bound to the pods.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1852648