### PR TITLE
lp 1858651: remove cluster-monitoring addons

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -45,6 +45,9 @@ def render_templates():
         "base_metrics_server_memory": "40Mi",
         "metrics_server_memory_per_node": "4",
         "metrics_server_min_cluster_size": "16",
+
+        # TODO: with removal of ./addons/cluster-monitoring, this is no longer used.
+        # Decide if we should remove monitorstorage support from here and k8s-master.
         "monitorstorage": get_snap_config("monitorstorage"),
 
         # may need to hack image names if our registry doesn't support multi-arch images
@@ -76,11 +79,6 @@ def render_templates():
             # default to basic auth as it used to be hard-coded
             dash_context['dashboard_auth'] = 'basic'
         render_template("kubernetes-dashboard.yaml", dash_context)
-        # monitorstorage
-        dash_ig_context = dash_context.copy()
-        dash_ig_context['monitorstorage'] = list(yaml.load_all(dash_ig_context['monitorstorage']))[0]
-        dash_ig_context['monitorstorage']['influxdb'] = yaml.dump(dash_ig_context['monitorstorage']['influxdb'])
-        dash_ig_context['monitorstorage']['grafana'] = yaml.dump(dash_ig_context['monitorstorage']['grafana'])
         rendered = True
     if get_snap_config("enable-gpu", required=False) == "true":
         render_template("nvidia-device-plugin.yml", context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -39,15 +39,6 @@ def render_templates():
             "num_nodes": node_count,
             "dns_memory_limit": "170Mi"
         },
-        # nanny_memory for heapster
-        # formula from https://github.com/kubernetes/kubernetes/blob/v1.9.6/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml#L11
-        "nanny_memory": str(90 * 1024 + node_count * 200) + "Ki",
-        # heapster server information taken from https://github.com/kubernetes/kubernetes/blob/8bd0a306b599bc8511a238c8c69c03c729767350/cluster/gce/gci/configure-helper.sh#L2349
-        "base_metrics_cpu": "80m",
-        "metrics_cpu_per_node": "0.5",
-        "base_metrics_memory": "140Mi",
-        "metrics_memory_per_node": "4",
-        "heapster_min_cluster_size": "16",
 
         # metrics server information taken from https://github.com/kubernetes/kubernetes/blob/8bd0a306b599bc8511a238c8c69c03c729767350/cluster/gce/gci/configure-helper.sh#L2402
         "base_metrics_server_cpu": "40m",
@@ -90,12 +81,6 @@ def render_templates():
         dash_ig_context['monitorstorage'] = list(yaml.load_all(dash_ig_context['monitorstorage']))[0]
         dash_ig_context['monitorstorage']['influxdb'] = yaml.dump(dash_ig_context['monitorstorage']['influxdb'])
         dash_ig_context['monitorstorage']['grafana'] = yaml.dump(dash_ig_context['monitorstorage']['grafana'])
-        render_template("influxdb-grafana-controller.yaml", dash_ig_context)
-        render_template("influxdb-service.yaml", dash_context)
-        render_template("grafana-service.yaml", dash_context)
-        render_template("heapster-rbac.yaml", dash_context)
-        render_template("heapster-controller.yaml", dash_context)
-        render_template("heapster-service.yaml", dash_context)
         rendered = True
     if get_snap_config("enable-gpu", required=False) == "true":
         render_template("nvidia-device-plugin.yml", context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -46,10 +46,6 @@ def render_templates():
         "metrics_server_memory_per_node": "4",
         "metrics_server_min_cluster_size": "16",
 
-        # TODO: with removal of ./addons/cluster-monitoring, this is no longer used.
-        # Decide if we should remove monitorstorage support from here and k8s-master.
-        "monitorstorage": get_snap_config("monitorstorage"),
-
         # may need to hack image names if our registry doesn't support multi-arch images
         "multiarch_workaround": "",
 

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -11,6 +11,6 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
            openstack-endpoint-ca enable-aws enable-azure enable-gcp \
-           monitorstorage cluster-tag; do
+           cluster-tag; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -189,35 +189,6 @@ def patch_ceph_storage_class(repo, file):
         f.write(content)
 
 
-def patch_heapster_controller(repo, file):
-    source = os.path.join(repo, 'cluster/addons', file)
-    with open(source, "r") as f:
-        content = f.read()
-    # setup kubelet connection to use https port 10250 since 10255 was deprecated due to security concerns
-    content = content.replace("kubernetes.summary_api:''", "kubernetes.summary_api:https://kubernetes.default?kubeletPort=10250&kubeletHttps=true")
-    with open(source, "w") as f:
-        f.write(content)
-
-
-def patch_influxdb_grafana(repo, file):
-    source = os.path.join(repo, 'cluster/addons', file)
-    with open(source, "r") as f:
-        content = f.read()
-    # LP 1822761: bump default influxdb container memory
-    content = content.replace("memory: 500M", "memory: 1100M")
-    content = content.replace("volumes:\n\
-      - name: influxdb-persistent-storage\n\
-        emptyDir: {}\n\
-      - name: grafana-persistent-storage\n\
-        emptyDir: {}", "volumes:\n\
-      - name: influxdb-persistent-storage\n\
-        {{ monitorstorage['influxdb'] }}\n\
-      - name: grafana-persistent-storage\n\
-        {{ monitorstorage['grafana'] }}")
-    with open(source, "w") as f:
-        f.write(content)
-
-
 def patch_metrics_server(repo, file):
     source = os.path.join(repo, 'cluster/addons', file)
     with open(source, "r") as f:
@@ -399,18 +370,6 @@ def get_addon_templates():
         kubedns = "dns/kube-dns"
         patch_kubedns(repo, kubedns + "/kube-dns.yaml.in")
         add_addon(repo, kubedns + "/kube-dns.yaml.in", dest + "/kube-dns.yaml")
-
-        influxdb = "cluster-monitoring/influxdb"
-        add_addon(repo, influxdb + "/grafana-service.yaml", dest)
-        patch_heapster_controller(repo, influxdb + "/heapster-controller.yaml")
-        add_addon(repo, influxdb + "/heapster-controller.yaml", dest)
-        add_addon(repo, influxdb + "/heapster-service.yaml", dest)
-        patch_influxdb_grafana(repo, influxdb + "/influxdb-grafana-controller.yaml")
-        add_addon(repo, influxdb + "/influxdb-grafana-controller.yaml", dest)
-        add_addon(repo, influxdb + "/influxdb-service.yaml", dest)
-
-        # Heapster RBAC
-        add_addon(repo, "cluster-monitoring/heapster-rbac.yaml", dest)
 
         # metrics server
         add_addon(repo, "metrics-server/auth-delegator.yaml", dest)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1858651

Upstream removed ./cluster/addons/cluster-monitoring in 1.18:

https://github.com/kubernetes/kubernetes/pull/85512

Get rid of the related bits in our cdk-addons snap.