### PR TITLE
remove mem limit from influx template

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -203,8 +203,14 @@ def patch_influxdb_grafana(repo, file):
     source = os.path.join(repo, 'cluster/addons', file)
     with open(source, "r") as f:
         content = f.read()
-    # LP 1822761: bump default influxdb container memory
-    content = content.replace("memory: 500M", "memory: 1100M")
+    # LP 1862209: remove influx mem limits
+    content = content.replace("            limits:\n"
+                              "              cpu: 100m\n"
+                              "              memory: 500Mi\n"
+                              "            requests:\n",
+                              "            limits:\n"
+                              "              cpu: 100m\n"
+                              "            requests:\n")
     content = content.replace("volumes:\n\
       - name: influxdb-persistent-storage\n\
         emptyDir: {}\n\


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/cdk-addons/+bug/1862209

Keep the default `requests`(500M), but get rid of the `limit`. [This means](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run) the pod won't be terminated for crossing the limit, but it may still be evicted if it exceeds the node's memory.

We need this in 1.15 - 1.17 because influx mem usage has crept up over the months to eventually OOM (see bug desc above). We won't need this in 1.18+ because cluster-monitoring (including influx) has been removed from addons.