### PR TITLE
update remaining cdk-addons pins for 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD=build
 KUBE_ARCH=amd64
-KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+# NB: change this to ./stable-1.xx.txt on relevant cdk-addons release-1.xx branches
+KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/latest.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)
 
@@ -11,11 +12,12 @@ PWD=$(shell pwd)
 # NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
-# pin coredns to 1.6.5
-COREDNS_COMMIT=50982715688fb0cb601f2da5e1f2c695a440a222
+# pin coredns to 1.6.6 commit (https://github.com/coredns/deployment)
+COREDNS_COMMIT=5a861f8a6fa192ac9dbda1856bff95b9d6721389
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=release-1.15
-KUBE_DASHBOARD_VERSION=v2.0.0-beta4
+# pin dashboard to latest v2 tag (https://github.com/kubernetes/dashboard)
+KUBE_DASHBOARD_VERSION=v2.0.0-rc5
 KUBE_STATE_METRICS_VERSION=release-1.8
 
 default: prep

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ COREDNS_COMMIT=5a861f8a6fa192ac9dbda1856bff95b9d6721389
 OPENSTACK_PROVIDER_COMMIT=release-1.15
 # pin dashboard to latest v2 tag (https://github.com/kubernetes/dashboard)
 KUBE_DASHBOARD_VERSION=v2.0.0-rc5
-KUBE_STATE_METRICS_VERSION=release-1.8
+# pin state metrics to 1.9.x branch (https://github.com/kubernetes/kube-state-metrics)
+KUBE_STATE_METRICS_VERSION=release-1.9
 
 default: prep
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ PWD=$(shell pwd)
 # NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
-# pin coredns to 1.6.6 commit (https://github.com/coredns/deployment)
-COREDNS_COMMIT=5a861f8a6fa192ac9dbda1856bff95b9d6721389
+# pin coredns to 1.6.7 commit (https://github.com/coredns/deployment)
+COREDNS_COMMIT=b0a81f926196cc750ea329476169ac89f0bfd78b
 # pin cloud-provider-openstack because it's under active dev
 OPENSTACK_PROVIDER_COMMIT=release-1.15
 # pin dashboard to latest v2 tag (https://github.com/kubernetes/dashboard)

--- a/cdk-addons.yaml
+++ b/cdk-addons.yaml
@@ -1,9 +1,9 @@
 name: cdk-addons
 version: 'KUBE_VERSION'
 architectures: ['KUBE_ARCH']
-summary: Addons for the Canonical Distribution of Kubernetes
+summary: Addons for Charmed Kubernetes
 description: |
-  Addons for the Canonical Distribution of Kubernetes
+  Addons for Charmed Kubernetes
 grade: stable
 confinement: strict
 apps:

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -119,11 +119,12 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         r"image: {{ registry|default('rocks.canonical.com/cdk') }}/addon-resizer-{{ arch }}:1.8.5",
         content
     )
-    # TODO: dashboard v2-b4 was needed late in the 1.16 release cycle. Once we verify
-    # rocks has a multi-arch manifest, stop forcing an -{{ arch }} string in the name.
+    # NB: dashboard has a multiarch manifest (https://hub.docker.com/u/kubernetesui/),
+    # but since arch-specific images are available, use them. This prevents potential
+    # arch-specific issues we may have when handling fat manifests in rocks.
     content = content.replace(
-        "kubernetesui/dashboard:v2.0.0-beta4",
-        "kubernetesui/dashboard-{{ arch }}:v2.0.0-beta4"
+        "kubernetesui/dashboard:v2.0.0",
+        "kubernetesui/dashboard-{{ arch }}:v2.0.0"
     )
     # Make sure images come from the configured registry (or use the default)
     content = re.sub(r"image:\s*cdkbot/",
@@ -512,7 +513,8 @@ def get_addon_templates():
         files = ["cluster-role-binding", "cluster-role", "deployment",
                  "service-account", "service"]
         for f in files:
-            add_addon(repo, "examples/standard/{}.yaml".format(f), dest, base='.')
+            add_addon(repo, "examples/standard/{}.yaml".format(f),
+                      "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
 
     for template in Path('bundled-templates').iterdir():
         shutil.copy2(str(template), dest)

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -512,7 +512,7 @@ def get_addon_templates():
         files = ["cluster-role-binding", "cluster-role", "deployment",
                  "service-account", "service"]
         for f in files:
-            add_addon(repo, "kubernetes/kube-state-metrics-{}.yaml".format(f), dest, base='.')
+            add_addon(repo, "examples/standard/{}.yaml".format(f), dest, base='.')
 
     for template in Path('bundled-templates').iterdir():
         shutil.copy2(str(template), dest)


### PR DESCRIPTION
https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1862236

Update the following for 1.18:

- coredns
- k8s-dashboard
- kube-state-metrics
