### PR TITLE
Revert ceph-csi v2.0 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ PWD=$(shell pwd)
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-# pin ceph-csi to currently available release branch
-CEPH_CSI_VERSION=release-v2.0
-# pin coredns to 1.6.7 commit (https://github.com/coredns/deployment)
+# NB Ceph: Need upstream issue resolved before we can bump ceph-csi commit
+# https://github.com/ceph/ceph-csi/issues/278
+CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=b0a81f926196cc750ea329476169ac89f0bfd78b
 # pin cloud-provider-openstack to currently available release branch
 OPENSTACK_PROVIDER_VERSION=release-1.17
@@ -39,7 +39,7 @@ docker: clean
 
 prep: clean
 	cp -r cdk-addons ${BUILD}
-	KUBE_ARCH=${KUBE_ARCH} KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_VERSION=${CEPH_CSI_VERSION} COREDNS_COMMIT=${COREDNS_COMMIT} OPENSTACK_PROVIDER_VERSION=${OPENSTACK_PROVIDER_VERSION} KUBE_STATE_METRICS_VERSION=${KUBE_STATE_METRICS_VERSION} ./get-addon-templates
+	KUBE_ARCH=${KUBE_ARCH} KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} CEPH_CSI_COMMIT=${CEPH_CSI_COMMIT} COREDNS_COMMIT=${COREDNS_COMMIT} OPENSTACK_PROVIDER_VERSION=${OPENSTACK_PROVIDER_VERSION} KUBE_STATE_METRICS_VERSION=${KUBE_STATE_METRICS_VERSION} ./get-addon-templates
 	mv templates ${BUILD}
 
 upstream-images: prep

--- a/bundled-templates/storageclass-openstack.yaml
+++ b/bundled-templates/storageclass-openstack.yaml
@@ -4,4 +4,4 @@ metadata:
   name: cdk-cinder
   annotations:
     juju.io/workload-storage: "true"
-provisioner: cinder.csi.openstack.org
+provisioner: csi-cinderplugin

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -95,19 +95,17 @@ def render_templates():
     if get_snap_config("enable-ceph", required=False) == "true":
         ceph_context = context.copy()
         default_storage = get_snap_config("default-storage", required=True)
-        ceph_context['admin_key'] = base64.b64decode(get_snap_config(
-            "ceph-admin-key", required=True)).decode('utf-8')
-        ceph_context['fsid'] = get_snap_config(
-            "ceph-fsid", required=True)
-        ceph_context['kubernetes_key'] = base64.b64decode(get_snap_config(
-            "ceph-kubernetes-key", required=True)).decode('utf-8')
-        ceph_context['mon_hosts'] = json.dumps(get_snap_config(
-            "ceph-mon-hosts", required=True).split())
+        ceph_context['admin_key'] = get_snap_config(
+            "ceph-admin-key", required=True)
+        ceph_context['kubernetes_key'] = get_snap_config(
+            "ceph-kubernetes-key", required=True)
+        ceph_context['mon_hosts'] = get_snap_config(
+            "ceph-mon-hosts", required=True)
 
         render_template("ceph-secret.yaml", ceph_context)
-        render_template("csi-config-map.yaml", ceph_context)
         render_template("csi-rbdplugin.yaml", ceph_context)
         render_template("csi-rbdplugin-provisioner.yaml", ceph_context)
+        render_template("csi-rbdplugin-attacher.yaml", ceph_context)
 
         ext4_context = ceph_context.copy()
         if default_storage == 'ceph-ext4':
@@ -132,18 +130,19 @@ def render_templates():
         render_template("ceph-storageclass.yaml", xfs_context,
                         render_filename="ceph-xfs-storageclass.yaml")
         # RBAC
+        render_template("csi-attacher-rbac.yaml", ceph_context)
         render_template("csi-nodeplugin-rbac.yaml", ceph_context)
         render_template("csi-provisioner-rbac.yaml", ceph_context)
 
         if get_snap_config("enable-cephfs", required=False) == "true":
             cephfs_context = ceph_context.copy()
             cephfs_context['default'] = (default_storage == 'cephfs')
-            cephfs_context['fsname'] = get_snap_config(
-                "ceph-fsname", required=True)
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin-provisioner.yaml", cephfs_context)
+            render_template("cephfs/csi-cephfsplugin-attacher.yaml", cephfs_context)
             render_template("cephfs/storageclass.yaml", cephfs_context)
+            render_template("cephfs/csi-attacher-rbac.yaml", cephfs_context)
             render_template("cephfs/csi-nodeplugin-rbac.yaml", cephfs_context)
             render_template("cephfs/csi-provisioner-rbac.yaml", cephfs_context)
         rendered = True
@@ -177,7 +176,7 @@ def render_templates():
         render_template("cloud-controller-manager-roles.yaml", openstack_context)
         render_template("cloud-controller-manager-role-bindings.yaml", openstack_context)
         render_template("openstack-cloud-controller-manager-ds.yaml", openstack_context)
-        render_template("cloud-config-secret-openstack.yaml", openstack_context)
+        render_template("cloud-config-secret.yaml", openstack_context)
 
         render_template("cinder-csi-controllerplugin-rbac.yaml", openstack_context)
         render_template("cinder-csi-controllerplugin.yaml", openstack_context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -6,8 +6,7 @@ mkdir "$SNAP_DATA/config"
 
 for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            enable-metrics enable-gpu registry \
-           ceph-admin-key ceph-kubernetes-key \
-           ceph-fsid ceph-fsname ceph-mon-hosts ceph-pool-name \
+           ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
            default-storage enable-ceph enable-keystone keystone-server-url \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import base64
 import os
 import re
 import shutil
@@ -78,8 +79,8 @@ nvidia_plugin_repo = repo_cloner(
 )
 
 ceph_csi_repo = repo_cloner(
-    url="https://github.com/ceph/ceph-csi.git",
-    branch=os.environ["CEPH_CSI_VERSION"]
+    url="http://github.com/ceph/ceph-csi.git",
+    commit=os.environ["CEPH_CSI_COMMIT"]
 )
 
 cloud_provider_openstack_repo = repo_cloner(
@@ -156,29 +157,12 @@ def patch_plugin_manifest(repo, file):
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
 
-def patch_ceph_config_map(repo, file):
-    source = os.path.join(repo, file)
-    with open(source, "r") as f:
-        content = f.read()
-    content = content.replace("config.json: |-\n    []", """config.json: |-
-    [
-      {
-        "clusterID": "{{ fsid }}",
-        "monitors":
-            {{ mon_hosts }}
-      }
-    ]""")
-    with open(source, "w") as f:
-        f.write(content)
-
-
 def patch_ceph_secret(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['stringData']['userID'] = "admin"
-    manifest['stringData']['userKey'] = "{{ kubernetes_key }}"
-    del manifest['stringData']['encryptionPassphrase']
+    manifest['data']['admin'] = "{{ admin_key }}"
+    manifest['data']['kubernetes'] = "{{ kubernetes_key }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
@@ -187,9 +171,10 @@ def patch_ceph_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['parameters']['clusterID'] = "{{ fsid }}"
+    manifest['parameters']['monitors'] = "{{ mon_hosts }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
-    manifest['parameters']['csi.storage.k8s.io/fstype'] = "{{ fs_type }}"
+    manifest['parameters']['fsType'] = "{{ fs_type }}"
+    manifest['parameters']['userid'] = "admin"
     manifest['metadata']['name'] = "{{ sc_name }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
@@ -210,11 +195,13 @@ def patch_cephfs_secret(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['stringData']['adminID'] = "admin"
-    manifest['stringData']['adminKey'] = "{{ admin_key }}"
+    # TODO: the base64 encoding of the adminID & userID will need to be removed
+    # when switching to ceph-csi 2.0.0
+    manifest['data']['adminID'] = base64.b64encode(b"admin").decode('utf-8')
+    manifest['data']['adminKey'] = "{{ admin_key }}"
     # k8s-master just passes in the admin key for both
-    manifest['stringData']['userID'] = "admin"
-    manifest['stringData']['userKey'] = "{{ kubernetes_key }}"
+    manifest['data']['userID'] = base64.b64encode(b"admin").decode('utf-8')
+    manifest['data']['userKey'] = "{{ kubernetes_key }}"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
@@ -223,10 +210,9 @@ def patch_cephfs_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['metadata']['name'] = "cephfs"
-    manifest['parameters']['clusterID'] = "{{ fsid }}"
-    manifest['parameters']['fsName'] = "{{ fsname }}"
+    manifest['parameters']['monitors'] = "{{ mon_hosts }}"
     manifest['parameters']['pool'] = "ceph-fs_data"
+    manifest['metadata']['name'] = "cephfs"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
@@ -369,6 +355,38 @@ def patch_kubedns(repo, file):
         f.write(content)
 
 
+def patch_for_1_16(repo, file, selector):
+    source = os.path.join(repo, file)
+    with open(source) as stream:
+        manifest = list(yaml.load_all(stream))
+    for doc in manifest:
+        if doc['kind'] == 'Deployment' or \
+           doc['kind'] == 'StatefulSet' or \
+           doc['kind'] == 'DaemonSet':
+            doc['apiVersion'] = 'apps/v1'
+            if 'selector' not in doc['spec']:
+                doc['spec']['selector'] = {}
+            doc['spec']['selector']['matchLabels'] = selector
+        elif doc['kind'] == 'NetworkPolicy':
+            doc['apiVersion'] = 'networking.k8s.io/v1'
+        elif doc['kind'] == 'PodSecurityPolicy':
+            doc['apiVersion'] = 'policy/v1beta1'
+    with open(source, "w") as yaml_file:
+        yaml.dump_all(manifest, yaml_file, default_flow_style=False)
+
+
+def patch_for_CVE_2019_11255(repo, file):
+    replace_images = [['/csi-provisioner:v1.0.1', '/csi-provisioner:v1.0.2'],
+                      ['/csi-snapshotter:v1.0.1', '/csi-snapshotter:v1.0.2']]
+    source = os.path.join(repo, file)
+    with open(source) as f:
+        content = f.read()
+    for i in replace_images:
+        content = content.replace(i[0], i[1])
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def get_addon_templates():
     """ Get addon templates. This will clone the kubernetes repo from upstream
     and copy addons to ./templates """
@@ -400,14 +418,17 @@ def get_addon_templates():
     with nvidia_plugin_repo() as repo:
         log.info("Copying nvidia plugin to " + dest)
         patch_plugin_manifest(repo, "nvidia-device-plugin.yml")
+        patch_for_1_16(repo, "nvidia-device-plugin.yml", {"name": "nvidia-device-plugin-ds"})
         add_addon(repo, "nvidia-device-plugin.yml", dest, base='.')
 
     with ceph_csi_repo() as repo:
         log.info("Copying ceph CSI templates to " + dest)
-        patch_ceph_config_map(repo, "deploy/rbd/kubernetes/csi-config-map.yaml")
-        add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
-
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", {"app": "csi-rbdplugin-provisioner"})
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", {"app": "csi-rbdplugin-attacher"})
+        patch_for_1_16(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", {"app": "csi-rbdplugin"})
+        patch_for_CVE_2019_11255(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
+        add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
 
         patch_ceph_secret(repo, "examples/rbd/secret.yaml")
@@ -417,13 +438,19 @@ def get_addon_templates():
         add_addon(repo, "examples/rbd/storageclass.yaml", os.path.join(dest, "ceph-storageclass.yaml"), base='.')
 
         # rbac templates
+        add_addon(repo, "deploy/rbd/kubernetes/csi-attacher-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml", dest, base='.')
         add_addon(repo, "deploy/rbd/kubernetes/csi-provisioner-rbac.yaml", dest, base='.')
 
         log.info("Copying CephFS CSI templates to " + dest)
         cephfs_dest = os.path.join(dest, 'cephfs')
         os.mkdir(cephfs_dest)
+        patch_for_1_16(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml", {"app": "csi-cephfsplugin-provisioner"})
+        patch_for_1_16(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml", {"app": "csi-cephfsplugin-attacher"})
+        patch_for_1_16(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml", {"app": "csi-cephfsplugin"})
+        patch_for_CVE_2019_11255(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml")
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml", cephfs_dest, base='.')
+        add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml", cephfs_dest, base='.')
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml", cephfs_dest, base='.')
 
         patch_cephfs_secret(repo, "examples/cephfs/secret.yaml")
@@ -433,6 +460,7 @@ def get_addon_templates():
         add_addon(repo, "examples/cephfs/storageclass.yaml", cephfs_dest, base='.')
 
         # rbac templates
+        add_addon(repo, "deploy/cephfs/kubernetes/csi-attacher-rbac.yaml", cephfs_dest, base='.')
         add_addon(repo, "deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml", cephfs_dest, base='.')
         add_addon(repo, "deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml", cephfs_dest, base='.')
 


### PR DESCRIPTION
This reverts PRs #168 and #169.

This can be re-reverted (see [LP #1867940](https://bugs.launchpad.net/cdk-addons/+bug/1867940)) once the Ussuri release of the OpenStack charms are available (targeted for Focal, presumably to be released in May 2020).

This addresses [LP #1868150](https://bugs.launchpad.net/cdk-addons/+bug/1868150)