### PR TITLE
Fix error when enable-openstack=true due to incorrect template name

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -176,7 +176,7 @@ def render_templates():
         render_template("cloud-controller-manager-roles.yaml", openstack_context)
         render_template("cloud-controller-manager-role-bindings.yaml", openstack_context)
         render_template("openstack-cloud-controller-manager-ds.yaml", openstack_context)
-        render_template("cloud-config-secret.yaml", openstack_context)
+        render_template("cloud-config-secret-openstack.yaml", openstack_context)
 
         render_template("cinder-csi-controllerplugin-rbac.yaml", openstack_context)
         render_template("cinder-csi-controllerplugin.yaml", openstack_context)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1871893

The template name was changed in https://github.com/charmed-kubernetes/cdk-addons/pull/167 but we missed a spot here.