### PR TITLE
track openstack release branch instead of tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ PWD=$(shell pwd)
 # https://github.com/ceph/ceph-csi/issues/278
 CEPH_CSI_COMMIT=a4dd8457350b4c4586743d78cbd5776437e618b6
 COREDNS_COMMIT=b0a81f926196cc750ea329476169ac89f0bfd78b
-# pin cloud-provider-openstack to currently available release tag
-OPENSTACK_PROVIDER_VERSION=v1.17.0
+# pin cloud-provider-openstack to currently available release branch
+OPENSTACK_PROVIDER_VERSION=release-1.17
 # pin dashboard to latest v2 tag (https://github.com/kubernetes/dashboard)
 KUBE_DASHBOARD_VERSION=v2.0.0-rc5
 # pin state metrics to 1.9.x branch (https://github.com/kubernetes/kube-state-metrics)


### PR DESCRIPTION
Tweak for https://bugs.launchpad.net/cdk-addons/+bug/1871945

Looks like an issue upstream where the `v1.17.0` tag is behind `release-1.17`. Unfortunately, it's a big deal as the 1 commit that it's missing controls which image versions are deployed, e.g.:

[cinder-csi-plugin v1.17.0](https://github.com/kubernetes/cloud-provider-openstack/blob/v1.17.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L86)
[cinder-csi-plugin release-1.17](https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.17/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L86)

Switch cdk-addons to track the release branch, since we want those images locked to a 1.17 version.