### PR TITLE
revert #130 now that we work with multiarch manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ prep: clean
 	mv templates ${BUILD}
 
 upstream-images: prep
-	$(eval RAW_IMAGES := "$(shell grep -hoE 'image:.*' ./${BUILD}/templates/* | sort -u)")
+	$(eval RAW_IMAGES := "$(shell grep -rhoE 'image:.*' ./${BUILD}/templates | sort -u)")
 # NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
 	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -18,12 +18,6 @@ dns_providers = {
     'kube-dns': 'kube-dns.yaml'
 }
 
-# Known registries that do not support multi-arch image manifests.
-single_arch_registries = [
-    'image-registry.canonical.com',
-    'rocks.canonical.com',
-]
-
 def main():
     if render_templates():
         apply_addons()
@@ -47,9 +41,6 @@ def render_templates():
         "metrics_server_memory_per_node": "4",
         "metrics_server_min_cluster_size": "16",
 
-        # may need to hack image names if our registry doesn't support multi-arch images
-        "multiarch_workaround": "",
-
         # let addons know what we're calling our cluster
         "cluster_tag": get_snap_config("cluster-tag", required=False),
     }
@@ -57,11 +48,6 @@ def render_templates():
     registry = get_snap_config("registry", required=False)
     if registry:
         context["registry"] = registry
-
-        for arch_reg in single_arch_registries:
-            if arch_reg in registry:
-                context["multiarch_workaround"] = "-{}".format(context["arch"])
-                break
 
     rendered = False
     dns_provider = get_snap_config("dns-provider")

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -331,26 +331,7 @@ def patch_coredns(repo, file):
     content = content.replace("clusterIP: CLUSTER_DNS_IP", "#clusterIP: CLUSTER_DNS_IP")
     content = content.replace(
         "image: coredns/coredns",
-        "image: {{ registry|default('docker.io') }}/coredns/coredns{{ multiarch_workaround }}")
-    with open(source, "w") as f:
-        f.write(content)
-
-
-def patch_kubedns(repo, file):
-    source = os.path.join(repo, 'cluster/addons', file)
-    with open(source, "r") as f:
-        content = f.read()
-    # Inject our hacky multiarch workaround until our registry supports fat manifests:
-    # https://github.com/charmed-kubernetes/cdk-addons/pull/130
-    content = content.replace(
-        "image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13",
-        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-kube-dns{{ multiarch_workaround }}:1.14.13")
-    content = content.replace(
-        "image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13",
-        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-dnsmasq-nanny{{ multiarch_workaround }}:1.14.13")
-    content = content.replace(
-        "image: k8s.gcr.io/k8s-dns-sidecar:1.14.13",
-        "image: {{ registry|default('k8s.gcr.io') }}/k8s-dns-sidecar{{ multiarch_workaround }}:1.14.13")
+        "image: {{ registry|default('docker.io') }}/coredns/coredns")
     with open(source, "w") as f:
         f.write(content)
 
@@ -395,9 +376,7 @@ def get_addon_templates():
     with kubernetes_repo() as repo:
         log.info("Copying addons to " + dest)
 
-        kubedns = "dns/kube-dns"
-        patch_kubedns(repo, kubedns + "/kube-dns.yaml.in")
-        add_addon(repo, kubedns + "/kube-dns.yaml.in", dest + "/kube-dns.yaml")
+        add_addon(repo, "dns/kube-dns/kube-dns.yaml.in", dest + "/kube-dns.yaml")
 
         # metrics server
         add_addon(repo, "metrics-server/auth-delegator.yaml", dest)


### PR DESCRIPTION
With https://github.com/charmed-kubernetes/jenkins/pull/576, jenkins now uses `ctr` to interact with images. Support for multi-arch manifests is much nicer with ctr, so this PR reverts our `{{ multiarch_workaround }}` hack that came in with #130.