### PR TITLE
remove alt-arch handling of metrics server image

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -235,10 +235,6 @@ def patch_metrics_server(repo, file):
     # nuke GKE specific stuff
     content = content.replace("- --kubelet-port=10255", "# - --kubelet-port=10255")
     content = content.replace("- --deprecated-kubelet-completely-insecure=true", "# - --deprecated-kubelet-completely-insecure=true")
-    # use v0.3.2 until latest (0.3.3) images are available for alt arches, eg:
-    # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-s390x?gcrImageListsize=30
-    if os.environ['KUBE_ARCH'] != 'amd64':
-        content = content.replace("v0.3.3", "v0.3.2")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
The current (v0.3.6) metrics-server is available for all arches, e.g.:

https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-amd64
https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-arm64
https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/metrics-server-s390x

Remove the logic that was holding alt-arches back to a known good image version.