### PR TITLE
allow missing key in recent metrics-server reader update

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -247,8 +247,12 @@ def patch_metrics_reader(repo, file):
     for doc in manifest:
         if doc['kind'] == 'ClusterRole':
             for rule in doc['rules']:
-                if '' in rule['apiGroups']:
-                    rule['resources'].append('nodes/stats')
+                try:
+                    if '' in rule['apiGroups']:
+                        rule['resources'].append('nodes/stats')
+                except KeyError:
+                    # In 1.19, not all rules have an 'apiGroups' key
+                    continue
     with open(source, "w") as yaml_file:
         yaml.dump_all(manifest, yaml_file, default_flow_style=False)
 


### PR DESCRIPTION
In 1.19, the `metrics-server` gained a new rule that doesn't include a key that we expect:

https://github.com/kubernetes/kubernetes/commit/5d93888f206fffa6789ed7c9440607fcd2380086#diff-e56c72ed8f82cf9883ae09e465a4675dR28

Allow for this when patching the metrics-server reader.