### PR TITLE
lock k8s-keystone-auth to a k8s version tag instead of "latest"

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -277,8 +277,8 @@ def patch_keystone_deployment(repo, file):
     # :-/ Would be nice to be able to add this template a different way
     with open(source, "r") as f:
         content = f.read()
-    content = content.replace("image: k8scloudprovider/k8s-keystone-auth",
-                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/k8s-keystone-auth")
+    content = content.replace("image: k8scloudprovider/k8s-keystone-auth:latest",
+                              "image: {{ registry|default('docker.io') }}/k8scloudprovider/k8s-keystone-auth:v1.19.0")
     content = content.replace("            - --keystone-url",
                               """{% if keystone_server_ca %}
             - --keystone-ca-file


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/cdk-addons/+bug/1895190

We want to lock `k8s-keystone-auth` to the [current release](https://hub.docker.com/r/k8scloudprovider/k8s-keystone-auth/tags) tag from upstream.