### PR TITLE
Fix error referencing ceph-fsname config

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -137,8 +137,6 @@ def render_templates():
         if get_snap_config("enable-cephfs", required=False) == "true":
             cephfs_context = ceph_context.copy()
             cephfs_context['default'] = (default_storage == 'cephfs')
-            cephfs_context['fsname'] = get_snap_config(
-                "ceph-fsname", required=True)
             cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1904063 for 1.18.

It looks like this statement got pulled in by accident with a cherry-pick: https://github.com/charmed-kubernetes/cdk-addons/commit/4f8db1e69950bc9ace97eccffc77156f0469e38a

Seems safe to remove, as fsname is not referenced anywhere else:

```
$ git grep fsname
cdk-addons/apply:            cephfs_context['fsname'] = get_snap_config(
cdk-addons/apply:                "ceph-fsname", required=True)
```