### PR TITLE
Make ceph-mounter config optional

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -134,7 +134,8 @@ def render_templates():
             cephfs_context['default'] = (default_storage == 'cephfs')
             cephfs_context['fsname'] = get_snap_config(
                 "ceph-fsname", required=True)
-            cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
+            cephfs_context['mounter'] = get_snap_config(
+                "cephfs-mounter", required=False) or "default"
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin-provisioner.yaml", cephfs_context)


### PR DESCRIPTION
Follow-up PR for https://bugs.launchpad.net/cdk-addons/+bug/1895352

This fixes the following error that occurs when running this change against current stable charms:

```
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status Traceback (most recent call last):
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status   File "/snap/cdk-addons/4723/apply", line 398, in <module>
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status     main()
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status   File "/snap/cdk-addons/4723/apply", line 24, in main
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status     if render_templates():
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status   File "/snap/cdk-addons/4723/apply", line 136, in render_templates
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status     cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status   File "/snap/cdk-addons/4723/apply", line 353, in get_snap_config
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status     raise MissingSnapConfig("%s is required" % name)
unit-kubernetes-master-0: 06:59:11 WARNING unit.kubernetes-master/0.update-status __main__.MissingSnapConfig: cephfs-mounter is required
```

This config needs to be optional before we can backport it.