### PR TITLE
[kube-state-metrics] add security context

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -138,10 +138,21 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         f.write(content)
 
 
+def load_yaml_file_from_repo(repo, file):
+    filepath = os.path.join(repo, file)
+    with open(filepath) as stream:
+        return filepath, yaml.load(stream)
+
+
+def patch_state_metrics_bug_1906303(repo, file):
+    filepath, manifest = load_yaml_file_from_repo(repo, file)
+    manifest["spec"]["template"]["spec"]["containers"][0]['securityContext'] = {"runAsUser":  65534}
+    with open(filepath, 'w') as yaml_file:
+        yaml.dump(manifest, yaml_file, default_flow_style=False)
+
+
 def patch_plugin_manifest(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['spec']['template']['spec']['containers'][0]['env'] = \
         [{'name': 'DP_DISABLE_HEALTHCHECKS', 'value': 'xids'}]
     manifest['spec']['template']['spec']['nodeSelector'] = {'gpu': 'true'}
@@ -165,9 +176,7 @@ def patch_ceph_config_map(repo, file):
 
 
 def patch_ceph_secret(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['stringData']['userID'] = "admin"
     manifest['stringData']['userKey'] = "{{ kubernetes_key }}"
     del manifest['stringData']['encryptionPassphrase']
@@ -176,9 +185,7 @@ def patch_ceph_secret(repo, file):
 
 
 def patch_ceph_storage_class(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['csi.storage.k8s.io/fstype'] = "{{ fs_type }}"
@@ -199,9 +206,7 @@ def patch_ceph_storage_class(repo, file):
 
 
 def patch_cephfs_secret(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['stringData']['adminID'] = "admin"
     manifest['stringData']['adminKey'] = "{{ admin_key }}"
     # k8s-master just passes in the admin key for both
@@ -212,9 +217,7 @@ def patch_cephfs_secret(repo, file):
 
 
 def patch_cephfs_storage_class(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['fsName'] = "{{ fsname }}"
     manifest['parameters']['pool'] = "ceph-fs_data"
@@ -450,8 +453,10 @@ def get_addon_templates():
         files = ["cluster-role-binding", "cluster-role", "deployment",
                  "service-account", "service"]
         for f in files:
-            add_addon(repo, "examples/standard/{}.yaml".format(f),
-                      "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
+            filepath = "examples/standard/{}.yaml".format(f)
+            if f in ("deployment", ):
+                patch_state_metrics_bug_1906303(repo, filepath)
+            add_addon(repo, filepath, "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
 
     for template in Path('bundled-templates').iterdir():
         shutil.copy2(str(template), dest)


### PR DESCRIPTION
Fixes LP: #1906303, by patching the deployment manifest of kube-state-metrics according to upstream patch
https://github.com/kubernetes/kube-state-metrics/pull/1034

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>