### PR TITLE
sub nvcr.io with our registry config

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -128,6 +128,9 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     content = re.sub(r"image:\s*nvidia/",
                      "image: {{ registry|default('docker.io') }}/nvidia/",
                      content)
+    content = re.sub(r"image:\s*nvcr.io/",
+                     "image: {{ registry|default('nvcr.io') }}/",
+                     content)
     content = re.sub(r"image:\s*quay.io/",
                      "image: {{ registry|default('quay.io') }}/",
                      content)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/cdk-addons/+bug/1916783

Substitute the new(er) nvcr.io repo url with our registry config.  Prior to this fix:
```bash
$ cat build/templates/nvidia-device-plugin.yml
...
        image: nvcr.io/nvidia/k8s-device-plugin:v0.8.2
...
```

With it:
```bash
        image: {{ registry|default('nvcr.io') }}/nvidia/k8s-device-plugin:v0.8.2
```

If we don't do this, CK customers will pull `k8s-device-plugin` from `nvcr.io` instead of `rocks`, which may not work in network-restricted environments.

FYI, I left the other nvidia substitution in tact in case we need to build cdk-addons for older k8s that still rely on `docker.io/nvidia/*`.