### PR TITLE
add compare targets to diff images from previous release; update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ upstream-images: prep
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
 
 compare-prep:
-	git clone --branch ${PREV_RELEASE} --single-branch https://github.com/charmed-kubernetes/cdk-addons.git ${PREV_RELEASE}
+	git clone --branch ${PREV_RELEASE} --single-branch --depth 1 https://github.com/charmed-kubernetes/cdk-addons.git ${PREV_RELEASE}
 	$(MAKE) -C ${PREV_RELEASE} prep
 
 compare-images: upstream-images compare-prep

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/latest.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)
 
+# cdk-addons release branch for comparing images. By default, this should be
+# set to the previous stable release-1.xx branch.
+PREV_RELEASE=release-1.20
+
 ## Pin some addons to known-good versions
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
@@ -26,7 +30,7 @@ default: prep
 	mv build/*.snap .
 
 clean:
-	@rm -rf ${BUILD} templates
+	@rm -rf ${BUILD} ${PREV_RELEASE} templates
 
 docker: clean
 	docker build -t cdk-addons-builder .
@@ -42,3 +46,15 @@ upstream-images: prep
 # NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
 	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
+
+compare-prep:
+	git clone --branch ${PREV_RELEASE} --single-branch https://github.com/charmed-kubernetes/cdk-addons.git ${PREV_RELEASE}
+	$(MAKE) -C ${PREV_RELEASE} prep
+
+compare-images: upstream-images compare-prep
+	$(eval PREV_RAW := "$(shell grep -rhoE 'image:.*' ./${PREV_RELEASE}/${BUILD}/templates | sort -u)")
+# NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
+	$(eval PREV_IMAGES := $(shell echo ${PREV_RAW} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
+# NB: compare image lists, only keeping those unique to UPSTREAM_IMAGES
+	$(eval NEW_IMAGES := $(shell bash -c "comm -13 <(echo ${PREV_IMAGES} | tr ' ' '\n' | sort) <(echo ${UPSTREAM_IMAGES} | tr ' ' '\n' | sort) | tr '\n' ' '"))
+	@echo "${KUBE_VERSION}-versus-${PREV_RELEASE}: ${NEW_IMAGES}"

--- a/README.md
+++ b/README.md
@@ -1,39 +1,54 @@
-# Charmed Distribution of Kubernetes Addons Snap
+# Charmed Kubernetes Addons Snap
 
-To build the cdk-addons snap, run `make` here and check for the results in the current directory.
+To build the cdk-addons snap, run `make` here and check for the results in the
+current directory.
 
 ```sh
 $ make
 
 $ ls *.snap
-cdk-addons_1.6.2_amd64.snap
+cdk-addons_1.20.2_amd64.snap
 ```
 
-By default, the latest stable version of Kubernetes is queried. To override this,
-set the `KUBE_VERSION` variable. The dashboard included by default is v1.6.3
-and you can override this via the KUBE_DASHBOARD_VERSION variable when calling make:
+By default, the latest stable version of Kubernetes is queried. To override
+this, set the `KUBE_VERSION` variable when calling make:
 
 ```sh
-$ make KUBE_VERSION=v1.7.1 KUBE_DASHBOARD_VERSION=v1.6.2
+$ make KUBE_VERSION=v1.20.2
 ```
 
 Make sure to include the `v` prefix when overriding versions.
 
-The `amd64` architecture is built by default. To select a different architecture,
-set the `KUBE_ARCH` variable when calling make:
+The `amd64` architecture is built by default. To select a different
+architecture, set the `KUBE_ARCH` variable when calling make:
 
 ```sh
 $ make KUBE_ARCH=arm64
 ```
 
-To build inside a docker container, use:
+To generate a list of images used by cdk-addons, use the `upstream-images`
+target:
 
 ```sh
-$ make docker
+$ make upstream-images
+...
+v1.21.0-beta.1-upstream: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.10 k8s.gcr.io/k8s-dns-kube-dns:1.15.10 k8s.gcr.io/k8s-dns-sidecar:1.15.10 k8s.gcr.io/metrics-server-{{ arch }}:v0.3.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 nvcr.io/nvidia/k8s-device-plugin:v0.9.0 quay.io/cephcsi/cephcsi:v2.1.2 quay.io/coreos/kube-state-metrics:v1.9.8 quay.io/k8scsi/csi-attacher:v2.1.1 quay.io/k8scsi/csi-node-driver-registrar:v1.3.0 quay.io/k8scsi/csi-provisioner:v1.4.0 quay.io/k8scsi/csi-resizer:v0.5.0 quay.io/k8scsi/csi-snapshotter:v1.2.2 rocks.canonical.com/cdk/addon-resizer-{{ arch }}:1.8.9
 ```
 
-and similarly:
+To generate a list of images that have changed since the last stable release,
+use the `compare-images` target:
 
 ```sh
-$ make KUBE_VERSION=v1.6.1 KUBE_ARCH=ppc64le docker
+$ make compare-images
+...
+v1.21.0-beta.1-versus-release-1.20: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 quay.io/coreos/kube-state-metrics:v1.9.8
+```
+
+To set explicit releases for image comparison, use `KUBE_VERSION` and
+`PREV_RELEASE` as needed:
+
+```sh
+$ make KUBE_VERSION=v1.20.2 PREV_RELEASE=release-1.19 compare-images
+...
+v1.20.2-versus-release-1.19: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 quay.io/coreos/kube-state-metrics:v1.9.8
 ```


### PR DESCRIPTION
Adds a couple `compare` targets so users (and CI) can generate a list of images that have changed since a previous release.  It works like this:
```bash
$ make compare-images
...
v1.21.0-beta.1-upstream: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.10 k8s.gcr.io/k8s-dns-kube-dns:1.15.10 k8s.gcr.io/k8s-dns-sidecar:1.15.10 k8s.gcr.io/metrics-server-{{ arch }}:v0.3.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 nvcr.io/nvidia/k8s-device-plugin:v0.9.0 quay.io/cephcsi/cephcsi:v2.1.2 quay.io/coreos/kube-state-metrics:v1.9.8 quay.io/k8scsi/csi-attacher:v2.1.1 quay.io/k8scsi/csi-node-driver-registrar:v1.3.0 quay.io/k8scsi/csi-provisioner:v1.4.0 quay.io/k8scsi/csi-resizer:v0.5.0 quay.io/k8scsi/csi-snapshotter:v1.2.2 rocks.canonical.com/cdk/addon-resizer-{{ arch }}:1.8.9
...
v1.21.0-beta.1-versus-release-1.20: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 quay.io/coreos/kube-state-metrics:v1.9.8
```

The releases default to latest k8s release compared to latest stable cdk-addons release, but can be overridden with `KUBE_VERSION` and `PREV_RELEASE` variables.

Partial fix for https://bugs.launchpad.net/cdk-addons/+bug/1891530; the rest will come from the jenkins job that uses this target to help the doc team highlight image changes in our release notes.
