### PR TITLE
bump ceph-csi to v3.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PREV_RELEASE=release-1.20
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-CEPH_CSI_COMMIT=bf0cc103228d54bcced0d76fc363ee1806484b32  # v3.2.1
+CEPH_CSI_COMMIT=a07260f19153cb6fef7cb27bfb9135082630830e  # v3.3.1
 COREDNS_COMMIT=316f8a857c06813cc899267a4428bf5ba4088d87  # v1.8.3
 OPENSTACK_PROVIDER_COMMIT=091078831af44b23f07180a21c5895e7c4ce8c09  # v1.20.0
 KUBE_DASHBOARD_COMMIT=0a30039e0111cbfd0c9bb09d6de6649e4a36fc3a  # v2.2.0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PREV_RELEASE=release-1.20
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-CEPH_CSI_COMMIT=a03675e3aeea093a48c389c5795730445356f3e1  # v2.1.2
+CEPH_CSI_COMMIT=bf0cc103228d54bcced0d76fc363ee1806484b32  # v3.2.1
 COREDNS_COMMIT=316f8a857c06813cc899267a4428bf5ba4088d87  # v1.8.3
 OPENSTACK_PROVIDER_COMMIT=091078831af44b23f07180a21c5895e7c4ce8c09  # v1.20.0
 KUBE_DASHBOARD_COMMIT=0a30039e0111cbfd0c9bb09d6de6649e4a36fc3a  # v2.2.0


### PR DESCRIPTION
Updated ceph-csi images bundled in cdk-addons to v3.2.1:

https://github.com/ceph/ceph-csi/commit/bf0cc103228d54bcced0d76fc363ee1806484b32

I double-checked the rbd and cephfs templates that cdk-addons manipulates, and there didn't seem to be any changes required between v2.1.2 and this v3.2.1.  K8s CI will exercise this in the `test_ceph` [validation](https://github.com/charmed-kubernetes/jenkins/blob/master/jobs/integration/validation.py) once this lands in a cdk-addons build.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1896765

Edit: now going to v3.3.1, the minimum version required for k8s 1.22.  See comment below.