### PR TITLE
Adding CSI volume snapshotter support (excluding validation webhook)

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -85,6 +85,14 @@ def render_templates():
         for t in kube_state_templates:
             render_template("kube-state-metrics-{}.yaml".format(t), context)
         rendered = True
+    if get_snap_config("enable-csi-snapshots", required=False) == "true":
+        render_template("snapshot.storage.k8s.io_volumesnapshotclasses.yaml", context)
+        render_template("snapshot.storage.k8s.io_volumesnapshotcontents.yaml", context)
+        render_template("snapshot.storage.k8s.io_volumesnapshots.yaml", context)
+        render_template("rbac-volume-snapshot-controller.yaml", context)
+        render_template("volume-snapshot-controller-deployment.yaml", context)
+        # To do: validation webhook
+        rendered = True
     if get_snap_config("enable-ceph", required=False) == "true":
         ceph_context = context.copy()
         default_storage = get_snap_config("default-storage", required=True)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -5,7 +5,7 @@ rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
 for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
-           enable-metrics enable-gpu registry \
+           enable-metrics enable-csi-snapshots enable-gpu registry \
            ceph-admin-key ceph-fsname ceph-fsid ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
            default-storage enable-ceph enable-keystone keystone-server-url \
            keystone-cert-file keystone-key-file keystone-server-ca \

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -367,6 +367,13 @@ def get_addon_templates():
         patch_metrics_reader(repo, "metrics-server/resource-reader.yaml")
         add_addon(repo, "metrics-server/resource-reader.yaml", dest)
 
+        # CSI snapshotter
+        add_addon(repo, "volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml", dest)
+        add_addon(repo, "volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml", dest)
+        add_addon(repo, "volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshots.yaml", dest)
+        add_addon(repo, "volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml", dest)
+        add_addon(repo, "volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml", dest)
+
     with kubernetes_dashboard_repo() as repo:
         log.info("Copying dashboard to " + dest)
         dashboard_yaml = 'aio/deploy/recommended.yaml'


### PR DESCRIPTION
This is an attempt (perhaps naive) at addressing https://bugs.launchpad.net/cdk-addons/+bug/1926494.

Dependent on: appropriate updates to charm-kubernetes-master

Known issue: This does not address the validation webhook, which appears to be an [optional, albeit recommended, component](https://github.com/kubernetes-csi/external-snapshotter#usage) of the feature.  I understand the overall details of how that would be integrated, so I would be open to looking into adding that as well.