### PR TITLE
Add tolerations to ceph-csi to bypass node taint restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 BUILD=build
 KUBE_ARCH=amd64
 # NB: change this to ./stable-1.xx.txt on relevant cdk-addons release-1.xx branches
-KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/latest.txt)
+KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable-1.19.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)
 
 # cdk-addons release branch for comparing images. By default, this should be
 # set to the previous stable release-1.xx branch.
-PREV_RELEASE=release-1.20
+PREV_RELEASE=release-1.18
 
 ## Pin some addons to known-good versions
 # NB: If we lock images to commits/versions, this could affect the image

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/latest.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)
 
+# cdk-addons release branch for comparing images. By default, this should be
+# set to the previous stable release-1.xx branch.
+PREV_RELEASE=release-1.20
+
 ## Pin some addons to known-good versions
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
@@ -26,7 +30,7 @@ default: prep
 	mv build/*.snap .
 
 clean:
-	@rm -rf ${BUILD} templates
+	@rm -rf ${BUILD} ${PREV_RELEASE} templates
 
 docker: clean
 	docker build -t cdk-addons-builder .
@@ -42,3 +46,15 @@ upstream-images: prep
 # NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
 	$(eval UPSTREAM_IMAGES := $(shell echo ${RAW_IMAGES} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
 	@echo "${KUBE_VERSION}-upstream: ${UPSTREAM_IMAGES}"
+
+compare-prep:
+	git clone --branch ${PREV_RELEASE} --single-branch --depth 1 https://github.com/charmed-kubernetes/cdk-addons.git ${PREV_RELEASE}
+	$(MAKE) -C ${PREV_RELEASE} prep
+
+compare-images: upstream-images compare-prep
+	$(eval PREV_RAW := "$(shell grep -rhoE 'image:.*' ./${PREV_RELEASE}/${BUILD}/templates | sort -u)")
+# NB: sed cleans up image prefix, quotes, and matches '{{ registry|default('k8s.gcr.io') }}/foo-{{ bar }}:latest', replacing the first {{..}} with the specified default registry
+	$(eval PREV_IMAGES := $(shell echo ${PREV_RAW} | sed -E -e "s/image: //g" -e "s/\{\{ registry\|default\(([^}]*)\) }}/\1/g" -e "s/['\"]//g"))
+# NB: compare image lists, only keeping those unique to UPSTREAM_IMAGES
+	$(eval NEW_IMAGES := $(shell bash -c "comm -13 <(echo ${PREV_IMAGES} | tr ' ' '\n' | sort) <(echo ${UPSTREAM_IMAGES} | tr ' ' '\n' | sort) | tr '\n' ' '"))
+	@echo "${KUBE_VERSION}-versus-${PREV_RELEASE}: ${NEW_IMAGES}"

--- a/README.md
+++ b/README.md
@@ -1,39 +1,54 @@
-# Charmed Distribution of Kubernetes Addons Snap
+# Charmed Kubernetes Addons Snap
 
-To build the cdk-addons snap, run `make` here and check for the results in the current directory.
+To build the cdk-addons snap, run `make` here and check for the results in the
+current directory.
 
 ```sh
 $ make
 
 $ ls *.snap
-cdk-addons_1.6.2_amd64.snap
+cdk-addons_1.20.2_amd64.snap
 ```
 
-By default, the latest stable version of Kubernetes is queried. To override this,
-set the `KUBE_VERSION` variable. The dashboard included by default is v1.6.3
-and you can override this via the KUBE_DASHBOARD_VERSION variable when calling make:
+By default, the latest stable version of Kubernetes is queried. To override
+this, set the `KUBE_VERSION` variable when calling make:
 
 ```sh
-$ make KUBE_VERSION=v1.7.1 KUBE_DASHBOARD_VERSION=v1.6.2
+$ make KUBE_VERSION=v1.20.2
 ```
 
 Make sure to include the `v` prefix when overriding versions.
 
-The `amd64` architecture is built by default. To select a different architecture,
-set the `KUBE_ARCH` variable when calling make:
+The `amd64` architecture is built by default. To select a different
+architecture, set the `KUBE_ARCH` variable when calling make:
 
 ```sh
 $ make KUBE_ARCH=arm64
 ```
 
-To build inside a docker container, use:
+To generate a list of images used by cdk-addons, use the `upstream-images`
+target:
 
 ```sh
-$ make docker
+$ make upstream-images
+...
+v1.21.0-beta.1-upstream: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.15.10 k8s.gcr.io/k8s-dns-kube-dns:1.15.10 k8s.gcr.io/k8s-dns-sidecar:1.15.10 k8s.gcr.io/metrics-server-{{ arch }}:v0.3.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 nvcr.io/nvidia/k8s-device-plugin:v0.9.0 quay.io/cephcsi/cephcsi:v2.1.2 quay.io/coreos/kube-state-metrics:v1.9.8 quay.io/k8scsi/csi-attacher:v2.1.1 quay.io/k8scsi/csi-node-driver-registrar:v1.3.0 quay.io/k8scsi/csi-provisioner:v1.4.0 quay.io/k8scsi/csi-resizer:v0.5.0 quay.io/k8scsi/csi-snapshotter:v1.2.2 rocks.canonical.com/cdk/addon-resizer-{{ arch }}:1.8.9
 ```
 
-and similarly:
+To generate a list of images that have changed since the last stable release,
+use the `compare-images` target:
 
 ```sh
-$ make KUBE_VERSION=v1.6.1 KUBE_ARCH=ppc64le docker
+$ make compare-images
+...
+v1.21.0-beta.1-versus-release-1.20: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 quay.io/coreos/kube-state-metrics:v1.9.8
+```
+
+To set explicit releases for image comparison, use `KUBE_VERSION` and
+`PREV_RELEASE` as needed:
+
+```sh
+$ make KUBE_VERSION=v1.20.2 PREV_RELEASE=release-1.19 compare-images
+...
+v1.20.2-versus-release-1.19: docker.io/coredns/coredns:1.8.3 docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.0 docker.io/k8scloudprovider/k8s-keystone-auth:v1.20.0 docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 docker.io/kubernetesui/dashboard:v2.2.0 docker.io/kubernetesui/metrics-scraper:v1.0.6 k8s.gcr.io/sig-storage/csi-attacher:v2.2.1 k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0 k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1 k8s.gcr.io/sig-storage/csi-resizer:v0.5.1 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3 k8s.gcr.io/sig-storage/livenessprobe:v2.1.0 quay.io/coreos/kube-state-metrics:v1.9.8
 ```

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -133,7 +133,6 @@ def render_templates():
             cephfs_context['default'] = (default_storage == 'cephfs')
             cephfs_context['fsname'] = get_snap_config(
                 "ceph-fsname", required=True)
-            cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin-provisioner.yaml", cephfs_context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -133,7 +133,8 @@ def render_templates():
             cephfs_context['default'] = (default_storage == 'cephfs')
             cephfs_context['fsname'] = get_snap_config(
                 "ceph-fsname", required=True)
-            cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
+            cephfs_context['mounter'] = get_snap_config(
+                "cephfs-mounter", required=False) or "default"
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin-provisioner.yaml", cephfs_context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -133,6 +133,7 @@ def render_templates():
             cephfs_context['default'] = (default_storage == 'cephfs')
             cephfs_context['fsname'] = get_snap_config(
                 "ceph-fsname", required=True)
+            cephfs_context['mounter'] = get_snap_config("cephfs-mounter") or "default"
             render_template("cephfs/secret.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin.yaml", cephfs_context)
             render_template("cephfs/csi-cephfsplugin-provisioner.yaml", cephfs_context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -11,6 +11,6 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
            openstack-endpoint-ca enable-aws enable-azure enable-gcp \
-           cluster-tag enable-cephfs; do
+           cluster-tag enable-cephfs cephfs-mounter; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -11,6 +11,6 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
            openstack-endpoint-ca enable-aws enable-azure enable-gcp \
-           cluster-tag enable-cephfs cephfs-mounter; do
+           cluster-tag enable-cephfs; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -219,6 +219,21 @@ def patch_cephfs_secret(repo, file):
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
 
+def patch_ceph_plugins(repo, file):
+    tolerations = {
+        'tolerations': [
+            {'operator': 'Exists', 'effect': 'NoExecute'},
+            {'operator': 'Exists', 'effect': 'NoSchedule'}
+        ]
+    }
+    filepath = os.path.join(repo, file)
+    with open(filepath) as stream:
+        manifest_list = list(yaml.load_all(stream))
+    manifest_list[0]["spec"]["template"]["spec"].update(tolerations)
+    with open(filepath, 'w') as yaml_file:
+        yaml.dump_all(manifest_list, yaml_file, default_flow_style=False)
+
+
 def patch_cephfs_storage_class(repo, file):
     source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
@@ -393,6 +408,7 @@ def get_addon_templates():
         add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
 
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
+        patch_ceph_plugins(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
 
         patch_ceph_secret(repo, "examples/rbd/secret.yaml")
@@ -409,6 +425,7 @@ def get_addon_templates():
         cephfs_dest = os.path.join(dest, 'cephfs')
         os.mkdir(cephfs_dest)
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml", cephfs_dest, base='.')
+        patch_ceph_plugins(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml")
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml", cephfs_dest, base='.')
 
         patch_cephfs_secret(repo, "examples/cephfs/secret.yaml")

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -138,10 +138,21 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         f.write(content)
 
 
+def load_yaml_file_from_repo(repo, file):
+    filepath = os.path.join(repo, file)
+    with open(filepath) as stream:
+        return filepath, yaml.load(stream)
+
+
+def patch_state_metrics_bug_1906303(repo, file):
+    filepath, manifest = load_yaml_file_from_repo(repo, file)
+    manifest["spec"]["template"]["spec"]["containers"][0]['securityContext'] = {"runAsUser":  65534}
+    with open(filepath, 'w') as yaml_file:
+        yaml.dump(manifest, yaml_file, default_flow_style=False)
+
+
 def patch_plugin_manifest(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['spec']['template']['spec']['containers'][0]['env'] = \
         [{'name': 'DP_DISABLE_HEALTHCHECKS', 'value': 'xids'}]
     manifest['spec']['template']['spec']['nodeSelector'] = {'gpu': 'true'}
@@ -165,9 +176,7 @@ def patch_ceph_config_map(repo, file):
 
 
 def patch_ceph_secret(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['stringData']['userID'] = "admin"
     manifest['stringData']['userKey'] = "{{ kubernetes_key }}"
     del manifest['stringData']['encryptionPassphrase']
@@ -176,9 +185,7 @@ def patch_ceph_secret(repo, file):
 
 
 def patch_ceph_storage_class(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['csi.storage.k8s.io/fstype'] = "{{ fs_type }}"
@@ -199,9 +206,7 @@ def patch_ceph_storage_class(repo, file):
 
 
 def patch_cephfs_secret(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['stringData']['adminID'] = "admin"
     manifest['stringData']['adminKey'] = "{{ admin_key }}"
     # k8s-master just passes in the admin key for both
@@ -212,9 +217,7 @@ def patch_cephfs_secret(repo, file):
 
 
 def patch_cephfs_storage_class(repo, file):
-    source = os.path.join(repo, file)
-    with open(source) as stream:
-        manifest = yaml.load(stream)
+    source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['fsName'] = "{{ fsname }}"
     manifest['parameters']['pool'] = "ceph-fs_data"
@@ -450,8 +453,10 @@ def get_addon_templates():
         files = ["cluster-role-binding", "cluster-role", "deployment",
                  "service-account", "service"]
         for f in files:
-            add_addon(repo, "examples/standard/{}.yaml".format(f),
-                      "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
+            filepath = "examples/standard/{}.yaml".format(f)
+            if f in ("deployment", ):
+                patch_state_metrics_bug_1906303(repo, filepath)
+            add_addon(repo, filepath, "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
 
     for template in Path('bundled-templates').iterdir():
         shutil.copy2(str(template), dest)

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -218,6 +218,7 @@ def patch_cephfs_storage_class(repo, file):
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['fsName'] = "{{ fsname }}"
     manifest['parameters']['pool'] = "ceph-fs_data"
+    manifest['parameters']['mounter'] = "PLACEHOLDER"
     manifest['metadata']['name'] = "cephfs"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
@@ -229,6 +230,10 @@ def patch_cephfs_storage_class(repo, file):
 {% if default == true %}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+{% endif %}""")
+    content = content.replace("  mounter: PLACEHOLDER",
+"""{%  if mounter != "default" %}
+  mounter: {{ mounter }}
 {% endif %}""")
     with open(source, "w") as f:
         f.write(content)

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -218,7 +218,6 @@ def patch_cephfs_storage_class(repo, file):
     manifest['parameters']['clusterID'] = "{{ fsid }}"
     manifest['parameters']['fsName'] = "{{ fsname }}"
     manifest['parameters']['pool'] = "ceph-fs_data"
-    manifest['parameters']['mounter'] = "PLACEHOLDER"
     manifest['metadata']['name'] = "cephfs"
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)
@@ -230,10 +229,6 @@ def patch_cephfs_storage_class(repo, file):
 {% if default == true %}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-{% endif %}""")
-    content = content.replace("  mounter: PLACEHOLDER",
-"""{%  if mounter != "default" %}
-  mounter: {{ mounter }}
 {% endif %}""")
     with open(source, "w") as f:
         f.write(content)

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -128,6 +128,9 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     content = re.sub(r"image:\s*nvidia/",
                      "image: {{ registry|default('docker.io') }}/nvidia/",
                      content)
+    content = re.sub(r"image:\s*nvcr.io/",
+                     "image: {{ registry|default('nvcr.io') }}/",
+                     content)
     content = re.sub(r"image:\s*quay.io/",
                      "image: {{ registry|default('quay.io') }}/",
                      content)


### PR DESCRIPTION
This fixes the scenario where a node having a taint on it prevents the ceph-csi pods from running on that node, rendering any other workloads on that node which require ceph broken.

To test:

Deploy CK with ceph-fs

Check pods on a particular node

```
$ kubectl get pods -n default -o wide | grep juju-d399d1-ck-8
csi-cephfsplugin-h2mm6                         3/3     Running   0          55s     10.5.0.26    juju-d399d1-ck-8    <none>           <none>
csi-rbdplugin-zzqzs                            3/3     Running   0          59s     10.5.0.26    juju-d399d1-ck-8    <none>           <none>
```

Add a taint to a node

`$ kubectl taint node juju-d399d1-ck-8 dedicated=testing:NoSchedule`

For speed and ease of testing, delete the ceph pods on that node
```
$ kubectl delete pods csi-cephfsplugin-h2mm6 csi-rbdplugin-zzqzs
pod "csi-cephfsplugin-h2mm6" deleted
pod "csi-rbdplugin-zzqzs" deleted
```
Note that the pods aren't recreated on the tainted node

`$ kubectl get pods -n default -o wide | grep juju-d399d1-ck-8`

Build the updated cdk-addons for your k8s version

`$ make KUBE_VERSION=v1.21.1`

Attach the new snap resource to kubernetes master

`$ juju attach kubernetes-master cdk-addons=./cdk-addons_1.21.1_amd64.snap`

Run upgrade
```
$ juju run-action kubernetes-master/0 upgrade
$ juju run-action kubernetes-master/1 upgrade
$ juju run-action kubernetes-master/2 upgrade
```
Take a look at the tainted node and see that the ceph pods are now back
```
kubectl get pods -n default -o wide | grep juju-d399d1-ck-8
csi-cephfsplugin-l7l45                         3/3     Running             0          58s   10.5.0.26    juju-d399d1-ck-8    <none>           <none>
csi-rbdplugin-pvcqw                            3/3     Running             0          20s   10.5.0.26    juju-d399d1-ck-8    <none>           <none>
```


Fixes: LP#1917663