### PR TITLE
Allow csi-ceph pods to run on tainted nodes

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -219,6 +219,21 @@ def patch_cephfs_secret(repo, file):
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
 
+def patch_ceph_plugins(repo, file):
+    tolerations = {
+        'tolerations': [
+            {'operator': 'Exists', 'effect': 'NoExecute'},
+            {'operator': 'Exists', 'effect': 'NoSchedule'}
+        ]
+    }
+    filepath = os.path.join(repo, file)
+    with open(filepath) as stream:
+        manifest_list = list(yaml.load_all(stream))
+    manifest_list[0]["spec"]["template"]["spec"].update(tolerations)
+    with open(filepath, 'w') as yaml_file:
+        yaml.dump_all(manifest_list, yaml_file, default_flow_style=False)
+
+
 def patch_cephfs_storage_class(repo, file):
     source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['parameters']['clusterID'] = "{{ fsid }}"
@@ -384,6 +399,7 @@ def get_addon_templates():
         add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
 
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
+        patch_ceph_plugins(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')
 
         patch_ceph_secret(repo, "examples/rbd/secret.yaml")
@@ -400,6 +416,7 @@ def get_addon_templates():
         cephfs_dest = os.path.join(dest, 'cephfs')
         os.mkdir(cephfs_dest)
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml", cephfs_dest, base='.')
+        patch_ceph_plugins(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml")
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml", cephfs_dest, base='.')
 
         patch_cephfs_secret(repo, "examples/cephfs/secret.yaml")


### PR DESCRIPTION
This fixes the scenario where a node having a taint on it prevents the ceph-csi pods from running on that node, rendering any other workloads on that node which require ceph broken.

To test:

Deploy CK with ceph-fs

Check pods on a particular node

```
$ kubectl get pods -o wide | grep juju-0b45d1-ck-15
csi-cephfsplugin-vdpnk                         3/3     Running   0          13m   10.5.2.49    juju-0b45d1-ck-15   <none>           <none>
csi-rbdplugin-5vbdh                            3/3     Running   0          13m   10.5.2.49    juju-0b45d1-ck-15   <none>           <none>
```

Add a taint to a node

`$ kubectl taint node juju-0b45d1-ck-15 dedicated=testing:NoSchedule`

For speed and ease of testing, delete the ceph pods on that node

`$ kubectl delete pods csi-cephfsplugin-vdpnk csi-rbdplugin-5vbdh`

Note that the pods aren't recreated on the tainted node

`$ kubectl get pods -o wide | grep juju-0b45d1-ck-15`

Build the updated cdk-addons for your k8s version

`$ make KUBE_VERSION=v1.21.1`

Attach the new snap resource to kubernetes master

`$ juju attach kubernetes-master cdk-addons=./cdk-addons_1.21.1_amd64.snap`

Run upgrade
```
$ juju run-action kubernetes-master/0 upgrade
$ juju run-action kubernetes-master/1 upgrade
$ juju run-action kubernetes-master/2 upgrade
```
Take a look at the tainted node and see that the ceph pods are now back
```
kubectl get pods -o wide | grep juju-0b45d1-ck-15
csi-cephfsplugin-p622x                         3/3     Running            0          5m49s   10.5.2.49    juju-0b45d1-ck-15   <none>           <none>
csi-rbdplugin-2s2tr                            3/3     Running            0          6m26s   10.5.2.49    juju-0b45d1-ck-15   <none>           <none>
```


Fixes: LP#1917663