### PR TITLE
Add branch check for compare-images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 templates
 *.snap
+release-*


### PR DESCRIPTION
Because of the external repos which are pinned in this repo's Makefile and thus are not influenced by the branch of the main Kubernetes repo, doing image comparisons when not on the proper release branch can give incorrect results. This adds a simple check to verify that the user is on the correct branch so that they don't silently get misleading results.

Fixes [lp:1940874](https://bugs.launchpad.net/cdk-addons/+bug/1940874)