### PR TITLE
1.24 updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,17 @@ REMOTE_BRANCH=$(strip $(shell git branch --list -r '*/'${RELEASE_BRANCH}))
 
 # cdk-addons release branch for comparing images. By default, this should be
 # set to the previous stable release-1.xx branch.
-PREV_RELEASE=release-1.20
+PREV_RELEASE=release-1.23
 
 ## Pin some addons to known-good versions
 # NB: If we lock images to commits/versions, this could affect the image
 # version matching in ./get-addon-templates. Be careful here, and verify
 # any images we need based on commit are matched/substituted correctly.
-CEPH_CSI_COMMIT=a07260f19153cb6fef7cb27bfb9135082630830e  # v3.3.1
-COREDNS_COMMIT=316f8a857c06813cc899267a4428bf5ba4088d87  # v1.8.3
-OPENSTACK_PROVIDER_COMMIT=a6a2bea4f376281887c7bcc2d1f612611e5f3dac  # v1.22.0
-KUBE_DASHBOARD_COMMIT=0a30039e0111cbfd0c9bb09d6de6649e4a36fc3a  # v2.2.0
-KUBE_STATE_METRICS_COMMIT=e72315512a38653b19dcfe4429f93eadedc0ea96  # v1.9.8
+CEPH_CSI_COMMIT=00f88e58a0b08be3d7ea009a0cfde8dca23021bf  # v3.5.1
+COREDNS_COMMIT=cb075b0a3810ccc0cb83339ddbce4b094c8f499b  # v1.9.0
+OPENSTACK_PROVIDER_COMMIT=1b5899e9f4c7c35e98e0be94732a88452b36cd15  # v1.23.1
+KUBE_DASHBOARD_COMMIT=52001304228c58430485674d21458527c8e6d86a  # v2.5.1
+KUBE_STATE_METRICS_COMMIT=ef8bede4064f04472a8c2fe8c281e6bf97de4329  # v2.4.2
 
 default: prep
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -147,13 +147,6 @@ def load_yaml_file_from_repo(repo, file):
         return filepath, yaml.safe_load(stream)
 
 
-def patch_state_metrics_bug_1906303(repo, file):
-    filepath, manifest = load_yaml_file_from_repo(repo, file)
-    manifest["spec"]["template"]["spec"]["containers"][0]['securityContext'] = {"runAsUser":  65534}
-    with open(filepath, 'w') as yaml_file:
-        yaml.dump(manifest, yaml_file, default_flow_style=False)
-
-
 def patch_plugin_manifest(repo, file):
     source, manifest = load_yaml_file_from_repo(repo, file)
     manifest['spec']['template']['spec']['containers'][0]['env'] = \
@@ -345,7 +338,6 @@ def patch_coredns(repo, file):
         content = f.read()
     content = content.replace("CLUSTER_DOMAIN", "{{ pillar['dns_domain'] }}")
     content = content.replace("REVERSE_CIDRS", "in-addr.arpa ip6.arpa")
-    content = content.replace("FEDERATIONS", "")
     content = content.replace("UPSTREAMNAMESERVER", "/etc/resolv.conf")
     content = content.replace("STUBDOMAINS", "")
     content = content.replace("fallthrough in-addr.arpa ip6.arpa",
@@ -469,8 +461,6 @@ def get_addon_templates():
                  "service-account", "service"]
         for f in files:
             filepath = "examples/standard/{}.yaml".format(f)
-            if f in ("deployment", ):
-                patch_state_metrics_bug_1906303(repo, filepath)
             add_addon(repo, filepath, "{}/kube-state-metrics-{}.yaml".format(dest, f), base='.')
 
     for template in Path('bundled-templates').iterdir():

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -252,35 +252,6 @@ def patch_cephfs_storage_class(repo, file):
         f.write(content)
 
 
-def patch_metrics_server(repo, file):
-    source = os.path.join(repo, 'cluster/addons', file)
-    with open(source, "r") as f:
-        content = f.read()
-    # nuke GKE specific stuff
-    content = content.replace("- --kubelet-port=10255", "# - --kubelet-port=10255")
-    content = content.replace("- --deprecated-kubelet-completely-insecure=true", "# - --deprecated-kubelet-completely-insecure=true")
-    with open(source, "w") as f:
-        f.write(content)
-
-
-def patch_metrics_reader(repo, file):
-    # add nodes/stats resource
-    source = os.path.join(repo, 'cluster/addons', file)
-    with open(source) as stream:
-        manifest = list(yaml.safe_load_all(stream))
-    for doc in manifest:
-        if doc['kind'] == 'ClusterRole':
-            for rule in doc['rules']:
-                try:
-                    if '' in rule['apiGroups']:
-                        rule['resources'].append('nodes/stats')
-                except KeyError:
-                    # In 1.19, not all rules have an 'apiGroups' key
-                    continue
-    with open(source, "w") as yaml_file:
-        yaml.dump_all(manifest, yaml_file, default_flow_style=False)
-
-
 def patch_keystone_deployment(repo, file):
     source = os.path.join(repo, file)
     # :-/ Would be nice to be able to add this template a different way
@@ -367,10 +338,8 @@ def get_addon_templates():
         add_addon(repo, "metrics-server/auth-delegator.yaml", dest)
         add_addon(repo, "metrics-server/auth-reader.yaml", dest)
         add_addon(repo, "metrics-server/metrics-apiservice.yaml", dest)
-        patch_metrics_server(repo, "metrics-server/metrics-server-deployment.yaml")
         add_addon(repo, "metrics-server/metrics-server-deployment.yaml", dest)
         add_addon(repo, "metrics-server/metrics-server-service.yaml", dest)
-        patch_metrics_reader(repo, "metrics-server/resource-reader.yaml")
         add_addon(repo, "metrics-server/resource-reader.yaml", dest)
 
     with kubernetes_dashboard_repo() as repo:

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -144,7 +144,7 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
 def load_yaml_file_from_repo(repo, file):
     filepath = os.path.join(repo, file)
     with open(filepath) as stream:
-        return filepath, yaml.load(stream)
+        return filepath, yaml.safe_load(stream)
 
 
 def patch_state_metrics_bug_1906303(repo, file):
@@ -227,7 +227,7 @@ def patch_ceph_plugins(repo, file):
     }
     filepath = os.path.join(repo, file)
     with open(filepath) as stream:
-        manifest_list = list(yaml.load_all(stream))
+        manifest_list = list(yaml.safe_load_all(stream))
     manifest_list[0]["spec"]["template"]["spec"].update(tolerations)
     with open(filepath, 'w') as yaml_file:
         yaml.dump_all(manifest_list, yaml_file, default_flow_style=False)
@@ -274,7 +274,7 @@ def patch_metrics_reader(repo, file):
     # add nodes/stats resource
     source = os.path.join(repo, 'cluster/addons', file)
     with open(source) as stream:
-        manifest = list(yaml.load_all(stream))
+        manifest = list(yaml.safe_load_all(stream))
     for doc in manifest:
         if doc['kind'] == 'ClusterRole':
             for rule in doc['rules']:


### PR DESCRIPTION
Update to current oci images for 1.24. Removed patches that were no longer relevant (upstream manifests no longer needed them). Drive-by to fix `yaml.load` warnings.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1968204