### PR TITLE
add required ceph-conf configmap template

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -104,6 +104,7 @@ def render_templates():
         render_template("csi-rbdplugin.yaml", ceph_context)
         render_template("csi-rbdplugin-provisioner.yaml", ceph_context)
         render_template("ceph-csi-encryption-kms-config.yaml", ceph_context)
+        render_template("ceph-conf.yaml", ceph_context)
 
         ext4_context = ceph_context.copy()
         if default_storage == 'ceph-ext4':

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -358,6 +358,8 @@ def get_addon_templates():
         patch_ceph_config_map(repo, "deploy/rbd/kubernetes/csi-config-map.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-config-map.yaml", dest, base='.')
 
+        add_addon(repo, "examples/ceph-conf.yaml", dest, base='.')
+
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml", dest, base='.')
         patch_ceph_plugins(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml")
         add_addon(repo, "deploy/rbd/kubernetes/csi-rbdplugin.yaml", dest, base='.')


### PR DESCRIPTION
Newish ceph-csi needs "yet another configmap" mounted in the pods:

https://docs.ceph.com/en/latest/rbd/rbd-kubernetes/#generate-ceph-csi-configmap
```
Recent versions of ceph-csi also require yet another ConfigMap object to define Ceph configuration to add to ceph.conf file inside CSI containers
```

Without this, pods failed like this:
```
  Normal   Scheduled    6m28s                  default-scheduler  Successfully assigned default/csi-cephfsplugin-sfbnl to juju-2407b6-9
  Warning  FailedMount  4m25s                  kubelet            Unable to attach or mount volumes: unmounted volumes=[ceph-config], unattached volumes=[keys-tmp-dir socket-dir plugin-dir host-dev ceph-csi-config registration-dir host-sys etc-selinux lib-modules host-mount kube-api-access-d6zxp mountpoint-dir ceph-config]: timed out waiting for the condition
  Warning  FailedMount  4m20s (x9 over 6m28s)  kubelet            MountVolume.SetUp failed for volume "ceph-config" : configmap "ceph-config" not found
```

With it, pods come up as expected.  The example/default conf that we're using [is here](https://github.com/ceph/ceph-csi/blob/v3.5.1/examples/ceph-conf.yaml).