### PR TITLE
include required csidriver for cephfs

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -297,6 +297,7 @@ def prune_addons():
             'apiservices',
             'clusterroles',
             'clusterrolebindings',
+            'csidrivers',
             'configmaps',
             'daemonsets',
             'deployments',

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -145,6 +145,7 @@ def render_templates():
             render_template("cephfs/storageclass.yaml", cephfs_context)
             render_template("cephfs/csi-nodeplugin-rbac.yaml", cephfs_context)
             render_template("cephfs/csi-provisioner-rbac.yaml", cephfs_context)
+            render_template("cephfs/csidriver.yaml", cephfs_context)
         rendered = True
     if get_snap_config("enable-keystone", required=False) == "true":
         keystone_context = context.copy()

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -391,6 +391,8 @@ def get_addon_templates():
         patch_ceph_plugins(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml")
         add_addon(repo, "deploy/cephfs/kubernetes/csi-cephfsplugin.yaml", cephfs_dest, base='.')
 
+        add_addon(repo, "deploy/cephfs/kubernetes/csidriver.yaml", cephfs_dest, base='.')
+
         patch_cephfs_secret(repo, "examples/cephfs/secret.yaml")
         add_addon(repo, "examples/cephfs/secret.yaml", cephfs_dest, base='.')
 


### PR DESCRIPTION
Adds [`cephfs/kubernetes/csidriver.yaml`](https://github.com/ceph/ceph-csi/blob/47b59ee5a430f66a88913bea1a6ac1961c8ff552/deploy/cephfs/kubernetes/csidriver.yaml) for cephfs to the addons

Resolves the issue documented here
https://github.com/ceph/ceph-csi/issues/3476#issuecomment-1293555145
