### PR TITLE
stop disabling gpu healthchecks

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -159,8 +159,6 @@ def load_yaml_file_from_repo(repo, file):
 
 def patch_plugin_manifest(repo, file):
     source, manifest = load_yaml_file_from_repo(repo, file)
-    manifest['spec']['template']['spec']['containers'][0]['env'] = \
-        [{'name': 'DP_DISABLE_HEALTHCHECKS', 'value': 'xids'}]
     manifest['spec']['template']['spec']['nodeSelector'] = {'gpu': 'true'}
     with open(source, 'w') as yaml_file:
         yaml.dump(manifest, yaml_file, default_flow_style=False)


### PR DESCRIPTION
Stop disabling health checks in the [v0.14 manifest](https://github.com/NVIDIA/k8s-device-plugin/blob/release-0.14/nvidia-device-plugin.yml). We missed this when bumping the device-plugin image in #223.

One nice side effect to this is that we stop clobbering the upstream env `FAIL_ON_INIT_ERROR`. Without that, `nvidia-smi` pod issues like the following could occur:
```
Pod was rejected: Allocate failed due to device plugin GetPreferredAllocation rpc failed with err: rpc error: code = Unknown desc = error getting list of preferred allocation devices: unable to retrieve list of available devices: error calling nvml.GetDeviceCount: nvml: Uninitialized, which is unexpected
```