### PR TITLE
Add cinder-availability-zone config

### DIFF
--- a/bundled-templates/storageclass-openstack.yaml
+++ b/bundled-templates/storageclass-openstack.yaml
@@ -5,3 +5,7 @@ metadata:
   annotations:
     juju.io/workload-storage: "true"
 provisioner: cinder.csi.openstack.org
+{% if cinder_availability_zone %}
+parameters:
+  availability: "{{ cinder_availability_zone }}"
+{% endif %}

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -172,6 +172,7 @@ def render_templates():
         openstack_context.update({
             "cloud_conf": get_snap_config("openstack-cloud-conf", required=True),
             "endpoint_ca_cert": get_snap_config("openstack-endpoint-ca", required=False),
+            "cinder_availability_zone": get_snap_config("cinder-availability-zone", required=False),
         })
 
         render_template("cloud-controller-manager-roles.yaml", openstack_context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -7,7 +7,7 @@ mkdir "$SNAP_DATA/config"
 for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
            enable-metrics enable-gpu registry \
            ceph-admin-key ceph-fsname ceph-fsid ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
-           ceph-user default-storage enable-ceph enable-keystone keystone-server-url \
+           ceph-user cinder-availability-zone default-storage enable-ceph enable-keystone keystone-server-url \
            keystone-cert-file keystone-key-file keystone-server-ca \
            dashboard-auth enable-openstack openstack-cloud-conf \
            openstack-endpoint-ca enable-aws enable-azure enable-gcp \


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1972861

This needs to be configurable in situations where Nova and Cinder have separate AZs.