### PR TITLE
[LP#2039886] re-write the `CLUSTER_NAME` env variable in the o7k ccm daemonset manifest

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -284,11 +284,10 @@ def patch_keystone_deployment(repo, file):
 def patch_openstack_ccm(repo, file):
     source = Path(repo) / file
     content = source.read_text()
-    content = content.replace('          args:\n'
-                              '            - /bin/openstack-cloud-controller-manager\n',
-                              '          args:\n'
-                              '            - /bin/openstack-cloud-controller-manager\n'
-                              '            - --cluster-name={{ cluster_tag }}\n')
+    content = content.replace('            - name: CLUSTER_NAME\n'
+                              '              value: kubernetes\n',
+                              '            - name: CLUSTER_NAME\n'
+                              '              value: {{ cluster_tag }}\n')
     source.write_text(content)
 
 


### PR DESCRIPTION
[LP#2039886](https://bugs.launchpad.net/cdk-addons/+bug/2039886)

https://github.com/kubernetes/cloud-provider-openstack/commit/93f74e5a6ee73c180a7734cbe23c889ffc63948b introduced a new `CLUSTER-NAME` environment variable rather than relying on patching the args of the daemonset.  CDK addons should stop setting the cluster-name via arg, and instead override the environment variable