### PR TITLE
Replace k8s-keystone-auth args with env vars

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -299,14 +299,34 @@ def patch_keystone_deployment(repo, file):
         + version,
         content,
     )
-    content = content.replace(
-        "            - --keystone-url",
-        """{% if keystone_server_ca %}
-            - --keystone-ca-file
-            - /etc/pki/ca.crt
-{% endif %}
-            - --keystone-url""",
+    # https://github.com/kubernetes/cloud-provider-openstack/issues/2464
+    # Replace command line arguments with environment variables
+    remove_args = (
+        "            - --tls-cert-file\n"
+        "            - /etc/pki/tls.crt\n"
+        "            - --tls-private-key-file\n"
+        "            - /etc/pki/tls.key\n"
+        "            - --policy-configmap-name\n"
+        "            - k8s-auth-policy\n"
+        "            - --keystone-url\n"
+        "            - {{ keystone_server_url }}\n"
     )
+    add_env = (
+        "          env:\n"
+        "            - name: OS_AUTH_URL\n"
+        "              value: {{ keystone_server_url }}\n"
+        "            - name: TLS_CERT_FILE\n"
+        "              value: /etc/pki/tls.crt\n"
+        "            - name: TLS_PRIVATE_KEY_FILE\n"
+        "              value: /etc/pki/tls.key\n"
+        "            - name: KEYSTONE_POLICY_CONFIGMAP_NAME\n"
+        "              value: k8s-auth-policy\n"
+        "{% if keystone_server_ca %}\n"
+        "            - name: KEYSTONE_CA_FILE\n"
+        "              value: /etc/pki/ca.crt\n"
+        "{% endif %}\n"
+    )
+    content = content.replace(remove_args, add_env)
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
It's no longer enough to alter args passed to k8s-keystone-auth, one must replace those args with environment variables.  This  may just be an issue with the upstream app so i've created an issue to track it

https://github.com/kubernetes/cloud-provider-openstack/issues/2464

In the meantime, its' no harm to swap to env vars