### PR TITLE
Include storageclasses to the pruned resource kinds

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -365,6 +365,7 @@ def prune_addons():
                 "services",
                 "serviceaccounts",
                 "statefulsets",
+                "storageclasses",
             ]
         ),
     )


### PR DESCRIPTION
## Overview
Address [LP#2073296](https://launchpad.net/bugs/2073296) to also remove/ignore storageclasses with a `cdk-addons=true` label

## Details

Add `storageclasses` to the list of resource kinds to search for which may be labeled with `cdk-addons: true`.  They will be either pruned or retired if they match