### PR TITLE
chore: Update PREV_RELEASE to release-1.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ REMOTE_BRANCH=$(strip $(shell git branch --list -r '*/'${RELEASE_BRANCH}))
 
 # cdk-addons release branch for comparing images. By default, this should be
 # set to the previous stable release-1.xx branch.
-PREV_RELEASE=release-1.31
+PREV_RELEASE=release-1.32
 
 ## Pin some addons to known-good versions
 # NB: If we lock images to commits/versions, this could affect the image


### PR DESCRIPTION
Updating the `PREV_REVISION` according to [this step](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#set-cdk-addons-envars).